### PR TITLE
ux_host_class_video: Save clock frequency during video channel start

### DIFF
--- a/common/usbx_host_classes/inc/ux_host_class_video.h
+++ b/common/usbx_host_classes/inc/ux_host_class_video.h
@@ -542,6 +542,7 @@ typedef struct UX_HOST_CLASS_VIDEO_STRUCT
     UCHAR           *ux_host_class_video_current_frame_address;
     ULONG           ux_host_class_video_current_frame_interval;
     ULONG           ux_host_class_video_current_max_payload_size;
+    ULONG           ux_host_class_video_current_clock_frequency;
     UX_TRANSFER     ux_host_class_video_transfer_requests[UX_HOST_CLASS_VIDEO_TRANSFER_REQUEST_COUNT];
     ULONG           ux_host_class_video_transfer_request_start_index;
     ULONG           ux_host_class_video_transfer_request_end_index;

--- a/common/usbx_host_classes/src/ux_host_class_video_channel_start.c
+++ b/common/usbx_host_classes/src/ux_host_class_video_channel_start.c
@@ -108,6 +108,7 @@ UX_ENDPOINT             *endpoint;
 ULONG                   endpoint_index;
 UINT                    streaming_interface;
 UINT                    max_payload_size;
+ULONG                   clock_frequency;
 
 
     /* Protect thread reentry to this instance.  */
@@ -202,6 +203,9 @@ UINT                    max_payload_size;
                         max_payload_size = video_parameter -> ux_host_class_video_parameter_channel_bandwidth_selection;
                     }
 
+                    /* Save clock frequency of the video stream */
+                    clock_frequency = _ux_utility_long_get(control_buffer + UX_HOST_CLASS_VIDEO_PROBE_COMMIT_CLOCK_FREQUENCY);
+
                     /* Search for the non zero alternate setting of the video stream.  */
                     status =  _ux_host_class_video_alternate_setting_locate(video, max_payload_size, &alternate_setting);
 
@@ -257,7 +261,10 @@ UINT                    max_payload_size;
                                                 It's not exceeding endpoint bandwidth since the interface alternate
                                                 setting is located by max payload size.  */
                                                 video -> ux_host_class_video_current_max_payload_size = max_payload_size;
-                        
+
+                                                /* Save the clock frequecny */
+                                                video -> ux_host_class_video_current_clock_frequency = clock_frequency;
+
                                                 /* Free all used resources.  */
                                                 _ux_utility_memory_free(control_buffer);
 


### PR DESCRIPTION
Knowing original stream clock frequency is very useful when video captured from USB is further streamed to the network, i.e. using RTP protocol.