### PR TITLE
add missing free allocated memory for device classes, fix typo

### DIFF
--- a/common/usbx_device_classes/CMakeLists.txt
+++ b/common/usbx_device_classes/CMakeLists.txt
@@ -90,6 +90,7 @@ target_sources(${PROJECT_NAME} PRIVATE
 	${CMAKE_CURRENT_LIST_DIR}/src/ux_device_class_dfu_state_sync.c
 	${CMAKE_CURRENT_LIST_DIR}/src/ux_device_class_dfu_tasks_run.c
 	${CMAKE_CURRENT_LIST_DIR}/src/ux_device_class_dfu_thread.c
+	${CMAKE_CURRENT_LIST_DIR}/src/ux_device_class_dfu_uninitialize.c
 	${CMAKE_CURRENT_LIST_DIR}/src/ux_device_class_hid_activate.c
 	${CMAKE_CURRENT_LIST_DIR}/src/ux_device_class_hid_control_request.c
 	${CMAKE_CURRENT_LIST_DIR}/src/ux_device_class_hid_deactivate.c
@@ -145,6 +146,7 @@ target_sources(${PROJECT_NAME} PRIVATE
 	${CMAKE_CURRENT_LIST_DIR}/src/ux_device_class_pima_storage_id_send.c
 	${CMAKE_CURRENT_LIST_DIR}/src/ux_device_class_pima_storage_info_get.c
 	${CMAKE_CURRENT_LIST_DIR}/src/ux_device_class_pima_thread.c
+	${CMAKE_CURRENT_LIST_DIR}/src/ux_device_class_pima_uninitialize.c
 	${CMAKE_CURRENT_LIST_DIR}/src/ux_device_class_printer_activate.c
 	${CMAKE_CURRENT_LIST_DIR}/src/ux_device_class_printer_control_request.c
 	${CMAKE_CURRENT_LIST_DIR}/src/ux_device_class_printer_deactivate.c
@@ -170,6 +172,7 @@ target_sources(${PROJECT_NAME} PRIVATE
 	${CMAKE_CURRENT_LIST_DIR}/src/ux_device_class_rndis_msg_query.c
 	${CMAKE_CURRENT_LIST_DIR}/src/ux_device_class_rndis_msg_reset.c
 	${CMAKE_CURRENT_LIST_DIR}/src/ux_device_class_rndis_msg_set.c
+	${CMAKE_CURRENT_LIST_DIR}/src/ux_device_class_rndis_uninitialize.c
 	${CMAKE_CURRENT_LIST_DIR}/src/ux_device_class_rndis_write.c
 	${CMAKE_CURRENT_LIST_DIR}/src/ux_device_class_storage_activate.c
 	${CMAKE_CURRENT_LIST_DIR}/src/ux_device_class_storage_control_request.c

--- a/common/usbx_device_classes/inc/ux_device_class_dfu.h
+++ b/common/usbx_device_classes/inc/ux_device_class_dfu.h
@@ -1,42 +1,42 @@
 /***************************************************************************
- * Copyright (c) 2024 Microsoft Corporation 
- * 
+ * Copyright (c) 2024 Microsoft Corporation
+ *
  * This program and the accompanying materials are made available under the
  * terms of the MIT License which is available at
  * https://opensource.org/licenses/MIT.
- * 
+ *
  * SPDX-License-Identifier: MIT
  **************************************************************************/
 
 /**************************************************************************/
 /**************************************************************************/
-/**                                                                       */ 
-/** USBX Component                                                        */ 
+/**                                                                       */
+/** USBX Component                                                        */
 /**                                                                       */
 /**   DFU Class                                                           */
 /**                                                                       */
 /**************************************************************************/
 /**************************************************************************/
 
-/**************************************************************************/ 
-/*                                                                        */ 
-/*  COMPONENT DEFINITION                                   RELEASE        */ 
-/*                                                                        */ 
-/*    ux_device_class_dfu.h                               PORTABLE C      */ 
-/*                                                           6.3.0        */
+/**************************************************************************/
+/*                                                                        */
+/*  COMPONENT DEFINITION                                   RELEASE        */
+/*                                                                        */
+/*    ux_device_class_dfu.h                               PORTABLE C      */
+/*                                                           6.x          */
 /*  AUTHOR                                                                */
 /*                                                                        */
 /*    Chaoqiong Xiao, Microsoft Corporation                               */
 /*                                                                        */
 /*  DESCRIPTION                                                           */
-/*                                                                        */ 
-/*    This file defines the equivalences for the USBX Device Class DFU    */ 
-/*    ACM component.                                                      */ 
-/*                                                                        */ 
-/*  RELEASE HISTORY                                                       */ 
-/*                                                                        */ 
-/*    DATE              NAME                      DESCRIPTION             */ 
-/*                                                                        */ 
+/*                                                                        */
+/*    This file defines the equivalences for the USBX Device Class DFU    */
+/*    ACM component.                                                      */
+/*                                                                        */
+/*  RELEASE HISTORY                                                       */
+/*                                                                        */
+/*    DATE              NAME                      DESCRIPTION             */
+/*                                                                        */
 /*  05-19-2020     Chaoqiong Xiao           Initial Version 6.0           */
 /*  09-30-2020     Chaoqiong Xiao           Modified comment(s),          */
 /*                                            used UX prefix to refer to  */
@@ -62,21 +62,25 @@
 /*  10-31-2023     Yajun xia                Modified comment(s),          */
 /*                                            added error checks support, */
 /*                                            resulting in version 6.3.0  */
+/*  xx-xx-xxxx     Mohamed ayed             Modified comment(s),          */
+/*                                            added dfu deinit function,  */
+/*                                            remove extra spaces,        */
+/*                                            resulting in version 6.x    */
 /*                                                                        */
 /**************************************************************************/
 
 #ifndef UX_DEVICE_CLASS_DFU_H
 #define UX_DEVICE_CLASS_DFU_H
 
-/* Determine if a C++ compiler is being used.  If so, ensure that standard 
-   C is used to process the API information.  */ 
+/* Determine if a C++ compiler is being used.  If so, ensure that standard
+   C is used to process the API information.  */
 
-#ifdef   __cplusplus 
+#ifdef   __cplusplus
 
-/* Yes, C++ compiler is present.  Use standard C.  */ 
-extern   "C" { 
+/* Yes, C++ compiler is present.  Use standard C.  */
+extern   "C" {
 
-#endif  
+#endif
 
 /* Internal option: enable the basic USBX error checking. This define is typically used
    while debugging application.  */
@@ -84,7 +88,7 @@ extern   "C" {
 #define UX_DEVICE_CLASS_DFU_ENABLE_ERROR_CHECKING
 #endif
 
-/* Define DFU class descriptor capabilities.  */                    
+/* Define DFU class descriptor capabilities.  */
 #define UX_SLAVE_CLASS_DFU_CAPABILITY_WILL_DETACH                   0x08
 #define UX_SLAVE_CLASS_DFU_CAPABILITY_MANIFESTATION_TOLERANT        0x04
 #define UX_SLAVE_CLASS_DFU_CAPABILITY_CAN_UPLOAD                    0x02
@@ -187,7 +191,7 @@ extern   "C" {
 /* Define DFU application notification signals.  */
 #define UX_SLAVE_CLASS_DFU_MEDIA_STATUS_OK                          0
 #define UX_SLAVE_CLASS_DFU_MEDIA_STATUS_BUSY                        1
-#define UX_SLAVE_CLASS_DFU_MEDIA_STATUS_ERROR                       2 
+#define UX_SLAVE_CLASS_DFU_MEDIA_STATUS_ERROR                       2
 
 /* Define DFU thread event signals.  */
 #define UX_DEVICE_CLASS_DFU_THREAD_EVENT_DISCONNECT                 0x1u
@@ -257,6 +261,7 @@ UINT  _ux_device_class_dfu_deactivate(UX_SLAVE_CLASS_COMMAND *command);
 UINT  _ux_device_class_dfu_entry(UX_SLAVE_CLASS_COMMAND *command);
 UINT  _ux_device_class_dfu_initialize(UX_SLAVE_CLASS_COMMAND *command);
 VOID  _ux_device_class_dfu_thread(ULONG dfu_class);
+UINT  _ux_device_class_dfu_uninitialize(UX_SLAVE_CLASS_COMMAND *command);
 
 UCHAR _ux_device_class_dfu_state_get(UX_SLAVE_CLASS_DFU *dfu);
 VOID  _ux_device_class_dfu_state_sync(UX_SLAVE_CLASS_DFU *dfu);
@@ -270,10 +275,10 @@ UINT  _uxe_device_class_dfu_initialize(UX_SLAVE_CLASS_COMMAND *command);
 #define ux_device_class_dfu_state_get    _ux_device_class_dfu_state_get
 #define ux_device_class_dfu_state_sync   _ux_device_class_dfu_state_sync
 
-/* Determine if a C++ compiler is being used.  If so, complete the standard 
-   C conditional started above.  */   
+/* Determine if a C++ compiler is being used.  If so, complete the standard
+   C conditional started above.  */
 #ifdef __cplusplus
-} 
-#endif 
+}
+#endif
 
 #endif /* UX_DEVICE_CLASS_DFU_H */

--- a/common/usbx_device_classes/inc/ux_device_class_pima.h
+++ b/common/usbx_device_classes/inc/ux_device_class_pima.h
@@ -1,18 +1,18 @@
 /***************************************************************************
- * Copyright (c) 2024 Microsoft Corporation 
- * 
+ * Copyright (c) 2024 Microsoft Corporation
+ *
  * This program and the accompanying materials are made available under the
  * terms of the MIT License which is available at
  * https://opensource.org/licenses/MIT.
- * 
+ *
  * SPDX-License-Identifier: MIT
  **************************************************************************/
 
 
 /**************************************************************************/
 /**************************************************************************/
-/**                                                                       */ 
-/** USBX Component                                                        */ 
+/**                                                                       */
+/** USBX Component                                                        */
 /**                                                                       */
 /**   PIMA Class                                                          */
 /**                                                                       */
@@ -20,25 +20,25 @@
 /**************************************************************************/
 
 
-/**************************************************************************/ 
-/*                                                                        */ 
-/*  COMPONENT DEFINITION                                   RELEASE        */ 
-/*                                                                        */ 
-/*    ux_device_class_pima.h                              PORTABLE C      */ 
-/*                                                           6.3.0        */
+/**************************************************************************/
+/*                                                                        */
+/*  COMPONENT DEFINITION                                   RELEASE        */
+/*                                                                        */
+/*    ux_device_class_pima.h                              PORTABLE C      */
+/*                                                           6.x          */
 /*  AUTHOR                                                                */
 /*                                                                        */
 /*    Chaoqiong Xiao, Microsoft Corporation                               */
 /*                                                                        */
 /*  DESCRIPTION                                                           */
-/*                                                                        */ 
+/*                                                                        */
 /*    This file contains all the header and extern functions used by the  */
-/*    USBX PIMA class.                                                    */ 
-/*                                                                        */ 
-/*  RELEASE HISTORY                                                       */ 
-/*                                                                        */ 
-/*    DATE              NAME                      DESCRIPTION             */ 
-/*                                                                        */ 
+/*    USBX PIMA class.                                                    */
+/*                                                                        */
+/*  RELEASE HISTORY                                                       */
+/*                                                                        */
+/*    DATE              NAME                      DESCRIPTION             */
+/*                                                                        */
 /*  05-19-2020     Chaoqiong Xiao           Initial Version 6.0           */
 /*  09-30-2020     Chaoqiong Xiao           Modified comment(s),          */
 /*                                            used UX prefix to refer to  */
@@ -63,21 +63,25 @@
 /*                                            endpoint buffer in classes, */
 /*                                            added error checks support, */
 /*                                            resulting in version 6.3.0  */
+/*  xx-xx-xxxx     Mohamed ayed             Modified comment(s),          */
+/*                                            added pima deinit function, */
+/*                                            remove extra spaces,        */
+/*                                            resulting in version 6.x    */
 /*                                                                        */
 /**************************************************************************/
 
 #ifndef UX_DEVICE_CLASS_PIMA_H
 #define UX_DEVICE_CLASS_PIMA_H
 
-/* Determine if a C++ compiler is being used.  If so, ensure that standard 
-   C is used to process the API information.  */ 
+/* Determine if a C++ compiler is being used.  If so, ensure that standard
+   C is used to process the API information.  */
 
-#ifdef   __cplusplus 
+#ifdef   __cplusplus
 
-/* Yes, C++ compiler is present.  Use standard C.  */ 
-extern   "C" { 
+/* Yes, C++ compiler is present.  Use standard C.  */
+extern   "C" {
 
-#endif  
+#endif
 
 
 /* Internal option: enable the basic USBX error checking. This define is typically used
@@ -109,7 +113,7 @@ extern   "C" {
 #define UX_DEVICE_CLASS_PIMA_PROTOCOL                                               0X01
 #define UX_DEVICE_CLASS_PIMA_MAGIC_NUMBER                                           0x50494D41
 #define UX_DEVICE_CLASS_PIMA_UNICODE_MAX_LENGTH                                     256
-#define UX_DEVICE_CLASS_PIMA_DATE_TIME_STRING_MAX_LENGTH                            64 
+#define UX_DEVICE_CLASS_PIMA_DATE_TIME_STRING_MAX_LENGTH                            64
 #define UX_DEVICE_CLASS_PIMA_MAX_EVENTS_QUEUE                                       16
 #define UX_DEVICE_CLASS_PIMA_MAX_STORAGE_IDS                                        1
 #define UX_DEVICE_CLASS_PIMA_ARRAY_MAX_LENGTH                                       256
@@ -117,13 +121,13 @@ extern   "C" {
 #define UX_DEVICE_CLASS_PIMA_OBJECT_PROPERTIES_ARRAY_MAX_ITEMS                      128
 #define UX_DEVICE_CLASS_PIMA_PROP_VALUE_SIZE                                        256
 #define UX_DEVICE_CLASS_PIMA_MICROSOFT_VENDOR_COMMAND_CODE                          0x54
-                                                                                    
-/* Define PIMA versions.  */                                                        
+
+/* Define PIMA versions.  */
 #define UX_DEVICE_CLASS_PIMA_STANDARD_VERSION                                       100
 #define UX_DEVICE_CLASS_PIMA_VENDOR_EXTENSION_ID                                    6
 #define UX_DEVICE_CLASS_PIMA_EXTENSION_VERSION                                      100
 #define UX_DEVICE_CLASS_PIMA_STANDARD_MODE                                          0
-                                                                                    
+
 
 /* Define PIMA phases.  */
 
@@ -133,80 +137,80 @@ extern   "C" {
 #define UX_DEVICE_CLASS_PIMA_PHASE_DATA_IN                                          3
 #define UX_DEVICE_CLASS_PIMA_PHASE_DATA_OUT                                         4
 
-/* Define PIMA data phases.  */                                                        
-                                                                                    
+/* Define PIMA data phases.  */
+
 #define UX_DEVICE_CLASS_PIMA_DATA_PHASE_NONE                                        0
 #define UX_DEVICE_CLASS_PIMA_DATA_PHASE_IN                                          1
 #define UX_DEVICE_CLASS_PIMA_DATA_PHASE_OUT                                         2
-                                                                                    
-/* Define PIMA session states.  */                                                    
-                                                                                    
+
+/* Define PIMA session states.  */
+
 #define UX_DEVICE_CLASS_PIMA_SESSION_STATE_CLOSED                                   0
 #define UX_DEVICE_CLASS_PIMA_SESSION_STATE_OPENED                                   1
-                                                                                    
-/* Define PIMA object and thumb states.  */                                            
-                                                                                    
+
+/* Define PIMA object and thumb states.  */
+
 #define UX_DEVICE_CLASS_PIMA_OBJECT_STATE_CLOSED                                    0
 #define UX_DEVICE_CLASS_PIMA_OBJECT_STATE_OPENED                                    1
-                                                                                    
-/* Define PIMA object and thumb transfer status.  */                                
-                                                                                    
+
+/* Define PIMA object and thumb transfer status.  */
+
 #define UX_DEVICE_CLASS_PIMA_OBJECT_TRANSFER_STATUS_INACTIVE                        0
 #define UX_DEVICE_CLASS_PIMA_OBJECT_TRANSFER_STATUS_ACTIVE                          1
 #define UX_DEVICE_CLASS_PIMA_OBJECT_TRANSFER_STATUS_COMPLETED                       2
 #define UX_DEVICE_CLASS_PIMA_OBJECT_TRANSFER_STATUS_ABORTED                         3
-                                                                                    
-/* Define PIMA object and thumb transfer phase.  */                                    
-                                                                                    
+
+/* Define PIMA object and thumb transfer phase.  */
+
 #define UX_DEVICE_CLASS_PIMA_OBJECT_TRANSFER_PHASE_ACTIVE                           0
 #define UX_DEVICE_CLASS_PIMA_OBJECT_TRANSFER_PHASE_COMPLETED                        1
 #define UX_DEVICE_CLASS_PIMA_OBJECT_TRANSFER_PHASE_COMPLETED_ERROR                  2
-                                                                                    
-                                                                                    
-/* Define PIMA Cancel Request equivalences.  */                                        
-                                                                                    
+
+
+/* Define PIMA Cancel Request equivalences.  */
+
 #define UX_DEVICE_CLASS_PIMA_REQUEST_CANCEL_COMMAND                                 0x64
 #define UX_DEVICE_CLASS_PIMA_REQUEST_CANCEL_DATA_LENGTH                             0x06
 #define UX_DEVICE_CLASS_PIMA_REQUEST_CANCEL_CODE                                    0x04001
 #define UX_DEVICE_CLASS_PIMA_REQUEST_CANCEL_OFFSET_CODE                             0x00
 #define UX_DEVICE_CLASS_PIMA_REQUEST_CANCEL_OFFSET_TRANSACTION_ID                   0x02
-                                                                                    
-/* Define PIMA Reset Request equivalences.  */                                        
-                                                                                    
+
+/* Define PIMA Reset Request equivalences.  */
+
 #define UX_DEVICE_CLASS_PIMA_REQUEST_RESET_DEVICE                                   0x66
-                                                                                    
-/* Define PIMA Status Request equivalences.  */                                        
-                                                                                    
+
+/* Define PIMA Status Request equivalences.  */
+
 #define UX_DEVICE_CLASS_PIMA_REQUEST_STATUS_COMMAND                                 0x67
 #define UX_DEVICE_CLASS_PIMA_REQUEST_STATUS_DATA_LENGTH                             0x40
 #define UX_DEVICE_CLASS_PIMA_REQUEST_STATUS_OFFSET_LENGTH                           0x00
 #define UX_DEVICE_CLASS_PIMA_REQUEST_STATUS_OFFSET_CODE                             0x02
 #define UX_DEVICE_CLASS_PIMA_REQUEST_STATUS_COMMAND_COUNTER                         16
-#define UX_DEVICE_CLASS_PIMA_REQUEST_STATUS_COMMAND_DELAY                           (1 * UX_PERIODIC_RATE) 
-                                                                                    
-/* Define PIMA command container type.  */                                            
-                                                                                    
+#define UX_DEVICE_CLASS_PIMA_REQUEST_STATUS_COMMAND_DELAY                           (1 * UX_PERIODIC_RATE)
+
+/* Define PIMA command container type.  */
+
 #define UX_DEVICE_CLASS_PIMA_CT_UNDEFINED                                           0x00
 #define UX_DEVICE_CLASS_PIMA_CT_COMMAND_BLOCK                                       0x01
 #define UX_DEVICE_CLASS_PIMA_CT_DATA_BLOCK                                          0x02
 #define UX_DEVICE_CLASS_PIMA_CT_RESPONSE_BLOCK                                      0x03
 #define UX_DEVICE_CLASS_PIMA_CT_EVENT_BLOCK                                         0x04
-                                                                                    
-/* Define PIMA Extended Event Data Request payload Format.  */                        
-                                                                                    
+
+/* Define PIMA Extended Event Data Request payload Format.  */
+
 #define UX_DEVICE_CLASS_PIMA_EEDR_EVENT_CODE                                        0x00
 #define UX_DEVICE_CLASS_PIMA_EEDR_TRANSACTION_ID                                    0x02
 #define UX_DEVICE_CLASS_PIMA_EEDR_NUMBER_PARAMETERS                                 0x06
 #define UX_DEVICE_CLASS_PIMA_EEDR_SIZE_PARAMETER                                    0x08
-                                                                                    
-/* Define PIMA Device Status Data Format.  */                                        
-                                                                                    
+
+/* Define PIMA Device Status Data Format.  */
+
 #define UX_DEVICE_CLASS_PIMA_DSD_LENGTH                                             0x00
 #define UX_DEVICE_CLASS_PIMA_DSD_CODE                                               0x02
 #define UX_DEVICE_CLASS_PIMA_DSD_PARAMETER                                          0x04
-                                                                                    
-/* Define PIMA Command Header Format.  */                                            
-                                                                                    
+
+/* Define PIMA Command Header Format.  */
+
 #define UX_DEVICE_CLASS_PIMA_COMMAND_HEADER_LENGTH                                  0x00
 #define UX_DEVICE_CLASS_PIMA_COMMAND_HEADER_TYPE                                    0x04
 #define UX_DEVICE_CLASS_PIMA_COMMAND_HEADER_CODE                                    0x06
@@ -216,31 +220,31 @@ extern   "C" {
 #define UX_DEVICE_CLASS_PIMA_COMMAND_HEADER_PARAMETER_3                             0x14
 #define UX_DEVICE_CLASS_PIMA_COMMAND_HEADER_PARAMETER_4                             0x18
 #define UX_DEVICE_CLASS_PIMA_COMMAND_HEADER_PARAMETER_5                             0x1C
-                                                                                    
+
 #define UX_DEVICE_CLASS_PIMA_COMMAND_HEADER_SIZE                                    0x0C
-#define UX_DEVICE_CLASS_PIMA_CONTAINER_SIZE                                         0x40 
+#define UX_DEVICE_CLASS_PIMA_CONTAINER_SIZE                                         0x40
 #define UX_DEVICE_CLASS_PIMA_ALL_HEADER_SIZE                                        0x20
-                                                                                    
-/* Define PIMA Data Header Format.  */                                                
-                                                                                    
+
+/* Define PIMA Data Header Format.  */
+
 #define UX_DEVICE_CLASS_PIMA_DATA_HEADER_LENGTH                                     0x00
 #define UX_DEVICE_CLASS_PIMA_DATA_HEADER_TYPE                                       0x04
 #define UX_DEVICE_CLASS_PIMA_DATA_HEADER_CODE                                       0x06
 #define UX_DEVICE_CLASS_PIMA_DATA_HEADER_TRANSACTION_ID                             0x08
 #define UX_DEVICE_CLASS_PIMA_DATA_HEADER_SIZE                                       0x0C
-                                                                                    
-                                                                                    
-/* Define PIMA Response Header Format.  */                                            
-                                                                                    
+
+
+/* Define PIMA Response Header Format.  */
+
 #define UX_DEVICE_CLASS_PIMA_RESPONSE_HEADER_LENGTH                                 0x00
 #define UX_DEVICE_CLASS_PIMA_RESPONSE_HEADER_TYPE                                   0x04
 #define UX_DEVICE_CLASS_PIMA_RESPONSE_HEADER_CODE                                   0x06
 #define UX_DEVICE_CLASS_PIMA_RESPONSE_HEADER_TRANSACTION_ID                         0x08
 #define UX_DEVICE_CLASS_PIMA_RESPONSE_HEADER_PARAMETERS                             0x0C
 #define UX_DEVICE_CLASS_PIMA_RESPONSE_HEADER_SIZE                                   0x0C
-                                                                                    
-/* Define PIMA Asynchronous Event Interrupt Data Format.  */                        
-                                                                                    
+
+/* Define PIMA Asynchronous Event Interrupt Data Format.  */
+
 #define UX_DEVICE_CLASS_PIMA_AEI_DATA_LENGTH                                        0x00
 #define UX_DEVICE_CLASS_PIMA_AEI_TYPE                                               0x04
 #define UX_DEVICE_CLASS_PIMA_AEI_EVENT_CODE                                         0x06
@@ -249,9 +253,9 @@ extern   "C" {
 #define UX_DEVICE_CLASS_PIMA_AEI_PARAMETER_2                                        0x10
 #define UX_DEVICE_CLASS_PIMA_AEI_PARAMETER_3                                        0x14
 #define UX_DEVICE_CLASS_PIMA_AEI_MAX_LENGTH                                         0x18
-                                                                                    
-/* Define PIMA Operation Commands.  */                                                
-                                                                                    
+
+/* Define PIMA Operation Commands.  */
+
 #define UX_DEVICE_CLASS_PIMA_OC_UNDEFINED                                           0x1000
 #define UX_DEVICE_CLASS_PIMA_OC_GET_DEVICE_INFO                                     0x1001
 #define UX_DEVICE_CLASS_PIMA_OC_OPEN_SESSION                                        0x1002
@@ -270,7 +274,7 @@ extern   "C" {
 #define UX_DEVICE_CLASS_PIMA_OC_FORMAT_STORE                                        0x100F
 #define UX_DEVICE_CLASS_PIMA_OC_RESET_DEVICE                                        0x1010
 #define UX_DEVICE_CLASS_PIMA_OC_SELF_TEST                                           0x1011
-#define UX_DEVICE_CLASS_PIMA_OC_SET_OBJECT_PROTECTION                               0x1012  
+#define UX_DEVICE_CLASS_PIMA_OC_SET_OBJECT_PROTECTION                               0x1012
 #define UX_DEVICE_CLASS_PIMA_OC_POWER_DOWN                                          0x1013
 #define UX_DEVICE_CLASS_PIMA_OC_GET_DEVICE_PROP_DESC                                0x1014
 #define UX_DEVICE_CLASS_PIMA_OC_GET_DEVICE_PROP_VALUE                               0x1015
@@ -288,8 +292,8 @@ extern   "C" {
 #define UX_DEVICE_CLASS_PIMA_OC_GET_OBJECT_REFERENCES                               0x9810
 #define UX_DEVICE_CLASS_PIMA_OC_SET_OBJECT_REFERENCES                               0x9811
 
-/* Define PIMA Response Codes.  */                                                    
-                                                                                    
+/* Define PIMA Response Codes.  */
+
 #define UX_DEVICE_CLASS_PIMA_RC_UNDEFINED                                           0x2000
 #define UX_DEVICE_CLASS_PIMA_RC_OK                                                  0x2001
 #define UX_DEVICE_CLASS_PIMA_RC_GENERAL_ERROR                                       0x2002
@@ -326,7 +330,7 @@ extern   "C" {
 #define UX_DEVICE_CLASS_PIMA_RC_OBJECT_ALREADY_OPENED                               0x2021
 #define UX_DEVICE_CLASS_PIMA_RC_OBJECT_ALREADY_CLOSED                               0x2022
 #define UX_DEVICE_CLASS_PIMA_RC_OBJECT_NOT_OPENED                                   0x2023
-                                                                                    
+
 #define UX_DEVICE_CLASS_PIMA_RC_INVALID_OBJECT_PROP_CODE                            0xA801
 #define UX_DEVICE_CLASS_PIMA_RC_INVALID_OBJECT_PROP_FORMAT                          0xA802
 #define UX_DEVICE_CLASS_PIMA_RC_INVALID_OBJECT_PROP_VALUE                           0xA803
@@ -336,9 +340,9 @@ extern   "C" {
 #define UX_DEVICE_CLASS_PIMA_RC_SPECIFICATION_BY_DEPTH_UNSUPPORTED                  0xA808
 #define UX_DEVICE_CLASS_PIMA_RC_OBJECT_TOO_LARGE                                    0xA809
 #define UX_DEVICE_CLASS_PIMA_RC_OBJECT_PROP_NOT_SUPPORTED                           0xA80A
-                                                                                    
-/* Define PIMA Event Codes.  */                                                        
-                                                                                    
+
+/* Define PIMA Event Codes.  */
+
 #define UX_DEVICE_CLASS_PIMA_EC_UNDEFINED                                           0x4000
 #define UX_DEVICE_CLASS_PIMA_EC_CANCEL_TRANSACTION                                  0x4001
 #define UX_DEVICE_CLASS_PIMA_EC_OBJECT_ADDED                                        0x4002
@@ -354,9 +358,9 @@ extern   "C" {
 #define UX_DEVICE_CLASS_PIMA_EC_STORAGE_INFO_CHANGED                                0x400C
 #define UX_DEVICE_CLASS_PIMA_EC_CAPTURE_COMPLETE                                    0x400D
 #define UX_DEVICE_CLASS_PIMA_EC_UNREPORTED_STATUS                                   0x400E
-                                                                                    
-/* Define PIMA Object Format Codes.  */                                                
-                                                                                    
+
+/* Define PIMA Object Format Codes.  */
+
 #define UX_DEVICE_CLASS_PIMA_OFC_UNDEFINED                                          0x3000
 #define UX_DEVICE_CLASS_PIMA_OFC_ASSOCIATION                                        0x3001
 #define UX_DEVICE_CLASS_PIMA_OFC_SCRIPT                                             0x3002
@@ -429,41 +433,41 @@ extern   "C" {
 #define UX_DEVICE_CLASS_PIMA_OFC_UNDEFINED_CONTACT                                  0xBB80
 #define UX_DEVICE_CLASS_PIMA_OFC_ABSTRACT_CONTACT                                   0xBB81
 #define UX_DEVICE_CLASS_PIMA_OFC_VCARD2                                             0xBB82
-                                                                                    
-/* Define PIMA Device Format Codes.  */                                                
-                                                                                    
-#define UX_DEVICE_CLASS_PIMA_DEV_PROP_UNDEFINED                                     0x5000 
-#define UX_DEVICE_CLASS_PIMA_DEV_PROP_BATTERY_LEVEL                                 0x5001 
-#define UX_DEVICE_CLASS_PIMA_DEV_PROP_FUNCTIONAL_MODE                               0x5002 
-#define UX_DEVICE_CLASS_PIMA_DEV_PROP_IMAGE_SIZE                                    0x5003 
-#define UX_DEVICE_CLASS_PIMA_DEV_PROP_COMPRESSION_SETTING                           0x5004 
-#define UX_DEVICE_CLASS_PIMA_DEV_PROP_WHITE_BALANCE                                 0x5005 
-#define UX_DEVICE_CLASS_PIMA_DEV_PROP_RGB_GAIN                                      0x5006 
-#define UX_DEVICE_CLASS_PIMA_DEV_PROP_F_NUMBER                                      0x5007 
-#define UX_DEVICE_CLASS_PIMA_DEV_PROP_FOCAL_LENGTH                                  0x5008 
-#define UX_DEVICE_CLASS_PIMA_DEV_PROP_FOCUS_DISTANCE                                0x5009 
-#define UX_DEVICE_CLASS_PIMA_DEV_PROP_FOCUS_MODE                                    0x500A 
-#define UX_DEVICE_CLASS_PIMA_DEV_PROP_EXPOSURE_METERING_MODE                        0x500B 
-#define UX_DEVICE_CLASS_PIMA_DEV_PROP_FLASH_MODE                                    0x500C 
-#define UX_DEVICE_CLASS_PIMA_DEV_PROP_EXPOSURE_TIME                                 0x500D 
-#define UX_DEVICE_CLASS_PIMA_DEV_PROP_EXPOSURE_PROGRAM_MODE                         0x500E 
-#define UX_DEVICE_CLASS_PIMA_DEV_PROP_EXPOSURE_INDEX                                0x500F 
-#define UX_DEVICE_CLASS_PIMA_DEV_PROP_EXPOSURE_BIAS_COMPENSATION                    0x5010 
-#define UX_DEVICE_CLASS_PIMA_DEV_PROP_DATE_TIME                                     0x5011 
-#define UX_DEVICE_CLASS_PIMA_DEV_PROP_CAPTURE_DELAY                                 0x5012 
-#define UX_DEVICE_CLASS_PIMA_DEV_PROP_STILL_CAPTURE_MODE                            0x5013 
-#define UX_DEVICE_CLASS_PIMA_DEV_PROP_CONTRAST                                      0x5014 
-#define UX_DEVICE_CLASS_PIMA_DEV_PROP_SHARPNESS                                     0x5015 
-#define UX_DEVICE_CLASS_PIMA_DEV_PROP_DIGITAL_ZOOM                                  0x5016 
-#define UX_DEVICE_CLASS_PIMA_DEV_PROP_EFFECT_MODE                                   0x5017 
-#define UX_DEVICE_CLASS_PIMA_DEV_PROP_BURST_NUMBER                                  0x5018 
-#define UX_DEVICE_CLASS_PIMA_DEV_PROP_BURST_INTERVAL                                0x5019 
-#define UX_DEVICE_CLASS_PIMA_DEV_PROP_TIME_LAPSE_NUMBER                             0x501A 
-#define UX_DEVICE_CLASS_PIMA_DEV_PROP_TIME_LAPSE_INTERVAL                           0x501B 
-#define UX_DEVICE_CLASS_PIMA_DEV_PROP_FOCUS_METERING_MODE                           0x501C 
-#define UX_DEVICE_CLASS_PIMA_DEV_PROP_UPLOAD_URL                                    0x501D 
-#define UX_DEVICE_CLASS_PIMA_DEV_PROP_ARTIST                                        0x501E 
-#define UX_DEVICE_CLASS_PIMA_DEV_PROP_COPYRIGHT_INFO                                0x501F 
+
+/* Define PIMA Device Format Codes.  */
+
+#define UX_DEVICE_CLASS_PIMA_DEV_PROP_UNDEFINED                                     0x5000
+#define UX_DEVICE_CLASS_PIMA_DEV_PROP_BATTERY_LEVEL                                 0x5001
+#define UX_DEVICE_CLASS_PIMA_DEV_PROP_FUNCTIONAL_MODE                               0x5002
+#define UX_DEVICE_CLASS_PIMA_DEV_PROP_IMAGE_SIZE                                    0x5003
+#define UX_DEVICE_CLASS_PIMA_DEV_PROP_COMPRESSION_SETTING                           0x5004
+#define UX_DEVICE_CLASS_PIMA_DEV_PROP_WHITE_BALANCE                                 0x5005
+#define UX_DEVICE_CLASS_PIMA_DEV_PROP_RGB_GAIN                                      0x5006
+#define UX_DEVICE_CLASS_PIMA_DEV_PROP_F_NUMBER                                      0x5007
+#define UX_DEVICE_CLASS_PIMA_DEV_PROP_FOCAL_LENGTH                                  0x5008
+#define UX_DEVICE_CLASS_PIMA_DEV_PROP_FOCUS_DISTANCE                                0x5009
+#define UX_DEVICE_CLASS_PIMA_DEV_PROP_FOCUS_MODE                                    0x500A
+#define UX_DEVICE_CLASS_PIMA_DEV_PROP_EXPOSURE_METERING_MODE                        0x500B
+#define UX_DEVICE_CLASS_PIMA_DEV_PROP_FLASH_MODE                                    0x500C
+#define UX_DEVICE_CLASS_PIMA_DEV_PROP_EXPOSURE_TIME                                 0x500D
+#define UX_DEVICE_CLASS_PIMA_DEV_PROP_EXPOSURE_PROGRAM_MODE                         0x500E
+#define UX_DEVICE_CLASS_PIMA_DEV_PROP_EXPOSURE_INDEX                                0x500F
+#define UX_DEVICE_CLASS_PIMA_DEV_PROP_EXPOSURE_BIAS_COMPENSATION                    0x5010
+#define UX_DEVICE_CLASS_PIMA_DEV_PROP_DATE_TIME                                     0x5011
+#define UX_DEVICE_CLASS_PIMA_DEV_PROP_CAPTURE_DELAY                                 0x5012
+#define UX_DEVICE_CLASS_PIMA_DEV_PROP_STILL_CAPTURE_MODE                            0x5013
+#define UX_DEVICE_CLASS_PIMA_DEV_PROP_CONTRAST                                      0x5014
+#define UX_DEVICE_CLASS_PIMA_DEV_PROP_SHARPNESS                                     0x5015
+#define UX_DEVICE_CLASS_PIMA_DEV_PROP_DIGITAL_ZOOM                                  0x5016
+#define UX_DEVICE_CLASS_PIMA_DEV_PROP_EFFECT_MODE                                   0x5017
+#define UX_DEVICE_CLASS_PIMA_DEV_PROP_BURST_NUMBER                                  0x5018
+#define UX_DEVICE_CLASS_PIMA_DEV_PROP_BURST_INTERVAL                                0x5019
+#define UX_DEVICE_CLASS_PIMA_DEV_PROP_TIME_LAPSE_NUMBER                             0x501A
+#define UX_DEVICE_CLASS_PIMA_DEV_PROP_TIME_LAPSE_INTERVAL                           0x501B
+#define UX_DEVICE_CLASS_PIMA_DEV_PROP_FOCUS_METERING_MODE                           0x501C
+#define UX_DEVICE_CLASS_PIMA_DEV_PROP_UPLOAD_URL                                    0x501D
+#define UX_DEVICE_CLASS_PIMA_DEV_PROP_ARTIST                                        0x501E
+#define UX_DEVICE_CLASS_PIMA_DEV_PROP_COPYRIGHT_INFO                                0x501F
 #define UX_DEVICE_CLASS_PIMA_DEV_PROP_SYNCHRONIZATION_PARTNER                       0xD401
 #define UX_DEVICE_CLASS_PIMA_DEV_PROP_DEVICE_FRIENDLY_NAME                          0xD402
 #define UX_DEVICE_CLASS_PIMA_DEV_PROP_VOLUME                                        0xD403
@@ -648,24 +652,24 @@ extern   "C" {
 
 #define UX_DEVICE_CLASS_PIMA_OPS_NO_PROTECTION                                      0x0000
 #define UX_DEVICE_CLASS_PIMA_OPS_READ_ONLY                                          0x0001
-                                                                    
-/* Define PIMA Storage Types Codes.  */                                                
-                                                                                    
+
+/* Define PIMA Storage Types Codes.  */
+
 #define UX_DEVICE_CLASS_PIMA_STC_UNDEFINED                                          0x0000
 #define UX_DEVICE_CLASS_PIMA_STC_FIXED_ROM                                          0x0001
 #define UX_DEVICE_CLASS_PIMA_STC_REMOVABLE_ROM                                      0x0002
 #define UX_DEVICE_CLASS_PIMA_STC_FIXED_RAM                                          0x0003
 #define UX_DEVICE_CLASS_PIMA_STC_REMOVABLE_RAM                                      0x0004
-                                                                                    
-/* Define PIMA File System Types Codes.  */                                            
-                                                                                    
+
+/* Define PIMA File System Types Codes.  */
+
 #define UX_DEVICE_CLASS_PIMA_FSTC_UNDEFINED                                         0x0000
 #define UX_DEVICE_CLASS_PIMA_FSTC_GENERIC_FLAT                                      0x0001
 #define UX_DEVICE_CLASS_PIMA_FSTC_GENERIC_HIERARCHICAL                              0x0002
 #define UX_DEVICE_CLASS_PIMA_FSTC_DCF                                               0x0003
-                                                                                    
-/* Define PIMA File System Access Types Codes.  */                                    
-                                                                                    
+
+/* Define PIMA File System Access Types Codes.  */
+
 #define UX_DEVICE_CLASS_PIMA_AC_READ_WRITE                                          0x0000
 #define UX_DEVICE_CLASS_PIMA_AC_RO_WITHOUT_OBJECT_DELETION                          0x0001
 #define UX_DEVICE_CLASS_PIMA_AC_RO_WITH_OBJECT_DELETION                             0x0002
@@ -720,7 +724,7 @@ typedef struct UX_SLAVE_CLASS_PIMA_EVENT_STRUCT
     ULONG                   ux_device_class_pima_event_parameter_1;
     ULONG                   ux_device_class_pima_event_parameter_2;
     ULONG                   ux_device_class_pima_event_parameter_3;
-    
+
 } UX_SLAVE_CLASS_PIMA_EVENT;
 
 /* Define PIMA object info structure.  */
@@ -755,7 +759,7 @@ typedef struct UX_SLAVE_CLASS_PIMA_OBJECT_STRUCT
     ULONG                   ux_device_class_pima_object_handle_id;
     ULONG                   ux_device_class_pima_object_length;
     UCHAR                   *ux_device_class_pima_object_buffer;
-    
+
 } UX_SLAVE_CLASS_PIMA_OBJECT;
 
 #define UX_SLAVE_CLASS_PIMA_OBJECT_DATA_LENGTH ((15 * sizeof(ULONG)) + \
@@ -770,7 +774,7 @@ typedef struct UX_SLAVE_CLASS_PIMA_SESSION_STRUCT
 {
 
     ULONG                   ux_device_class_pima_session_id;
-    
+
 } UX_SLAVE_CLASS_PIMA_SESSION;
 
 /* Define PIMA device info structure.  */
@@ -792,28 +796,28 @@ typedef struct UX_SLAVE_CLASS_PIMA_DEVICE_STRUCT
     UCHAR                   ux_device_class_pima_device_model[UX_DEVICE_CLASS_PIMA_DATE_TIME_STRING_MAX_LENGTH];
     UCHAR                   ux_device_class_pima_device_version[UX_DEVICE_CLASS_PIMA_DATE_TIME_STRING_MAX_LENGTH];
     UCHAR                   ux_device_class_pima_device_serial_number[UX_DEVICE_CLASS_PIMA_UNICODE_MAX_LENGTH];
-    
+
 } UX_SLAVE_CLASS_PIMA_DEVICE;
 
-/* Define PIMA storage info structure.  */                                              
-                                                                                        
-typedef struct UX_SLAVE_CLASS_PIMA_STORAGE_STRUCT                                        
-{                                                                                       
-                                                                                        
-    USHORT                  ux_device_class_pima_storage_type;                                               
-    USHORT                  ux_device_class_pima_storage_file_system_type;                                   
-    USHORT                  ux_device_class_pima_storage_access_capability;                                  
+/* Define PIMA storage info structure.  */
+
+typedef struct UX_SLAVE_CLASS_PIMA_STORAGE_STRUCT
+{
+
+    USHORT                  ux_device_class_pima_storage_type;
+    USHORT                  ux_device_class_pima_storage_file_system_type;
+    USHORT                  ux_device_class_pima_storage_access_capability;
     USHORT                  _align_max_capacity_low;
-    ULONG                   ux_device_class_pima_storage_max_capacity_low;                                   
-    ULONG                   ux_device_class_pima_storage_max_capacity_high;                                  
-    ULONG                   ux_device_class_pima_storage_free_space_bytes_low;                               
-    ULONG                   ux_device_class_pima_storage_free_space_bytes_high;                              
-    ULONG                   ux_device_class_pima_storage_free_space_images;                                  
-    UCHAR                   ux_device_class_pima_storage_description[UX_DEVICE_CLASS_PIMA_UNICODE_MAX_LENGTH]; 
+    ULONG                   ux_device_class_pima_storage_max_capacity_low;
+    ULONG                   ux_device_class_pima_storage_max_capacity_high;
+    ULONG                   ux_device_class_pima_storage_free_space_bytes_low;
+    ULONG                   ux_device_class_pima_storage_free_space_bytes_high;
+    ULONG                   ux_device_class_pima_storage_free_space_images;
+    UCHAR                   ux_device_class_pima_storage_description[UX_DEVICE_CLASS_PIMA_UNICODE_MAX_LENGTH];
     UCHAR                   ux__class_pima_storage_volume_label[UX_DEVICE_CLASS_PIMA_UNICODE_MAX_LENGTH];
-                                                                                        
-} UX_SLAVE_CLASS_PIMA_STORAGE;                                                           
-                                                                                        
+
+} UX_SLAVE_CLASS_PIMA_STORAGE;
+
 /* Define PIMA structure.  */
 
 typedef struct UX_SLAVE_CLASS_PIMA_STRUCT
@@ -852,13 +856,13 @@ typedef struct UX_SLAVE_CLASS_PIMA_STRUCT
     UCHAR                   *ux_device_class_pima_interrupt_thread_stack;
     UX_SEMAPHORE            ux_device_class_pima_interrupt_thread_semaphore;
 #endif
-    UX_SLAVE_CLASS_PIMA_EVENT    
+    UX_SLAVE_CLASS_PIMA_EVENT
                             *ux_device_class_pima_event_array;
-    UX_SLAVE_CLASS_PIMA_EVENT    
+    UX_SLAVE_CLASS_PIMA_EVENT
                             *ux_device_class_pima_event_array_head;
-    UX_SLAVE_CLASS_PIMA_EVENT    
+    UX_SLAVE_CLASS_PIMA_EVENT
                             *ux_device_class_pima_event_array_tail;
-    UX_SLAVE_CLASS_PIMA_EVENT    
+    UX_SLAVE_CLASS_PIMA_EVENT
                             *ux_device_class_pima_event_array_end;
     USHORT                  *ux_device_class_pima_device_properties_list;
     USHORT                  *ux_device_class_pima_supported_capture_formats_list;
@@ -866,16 +870,16 @@ typedef struct UX_SLAVE_CLASS_PIMA_STRUCT
     USHORT                  *ux_device_class_pima_object_properties_list;
     UINT                    (*ux_device_class_pima_cancel)(struct UX_SLAVE_CLASS_PIMA_STRUCT *pima);
     UINT                    (*ux_device_class_pima_device_reset)(struct UX_SLAVE_CLASS_PIMA_STRUCT *pima);
-    
+
     UINT                    (*ux_device_class_pima_device_prop_desc_get)(struct UX_SLAVE_CLASS_PIMA_STRUCT *pima, ULONG device_property, UCHAR **device_prop_dataset, ULONG *device_prop_dataset_length);
     UINT                    (*ux_device_class_pima_device_prop_value_get)(struct UX_SLAVE_CLASS_PIMA_STRUCT *pima, ULONG device_property, UCHAR **device_prop_value, ULONG *device_prop_value_length);
     UINT                    (*ux_device_class_pima_device_prop_value_set)(struct UX_SLAVE_CLASS_PIMA_STRUCT *pima, ULONG device_property, UCHAR *device_prop_value, ULONG device_prop_value_length);
-    
+
     UINT                    (*ux_device_class_pima_storage_format)(struct UX_SLAVE_CLASS_PIMA_STRUCT *pima, ULONG storage_id);
     UINT                    (*ux_device_class_pima_storage_info_get)(struct UX_SLAVE_CLASS_PIMA_STRUCT *pima, ULONG storage_id);
     UINT                    (*ux_device_class_pima_object_number_get)(struct UX_SLAVE_CLASS_PIMA_STRUCT *pima, ULONG object_format_code, ULONG object_association, ULONG *object_number);
-    UINT                    (*ux_device_class_pima_object_handles_get)(struct UX_SLAVE_CLASS_PIMA_STRUCT *pima, ULONG object_handles_format_code, 
-                                                                        ULONG object_handles_association, 
+    UINT                    (*ux_device_class_pima_object_handles_get)(struct UX_SLAVE_CLASS_PIMA_STRUCT *pima, ULONG object_handles_format_code,
+                                                                        ULONG object_handles_association,
                                                                         ULONG *object_handles_array,
                                                                         ULONG object_handles_max_number);
     UINT                    (*ux_device_class_pima_object_info_get)(struct UX_SLAVE_CLASS_PIMA_STRUCT *pima, ULONG object_handle, UX_SLAVE_CLASS_PIMA_OBJECT **object);
@@ -893,8 +897,8 @@ typedef struct UX_SLAVE_CLASS_PIMA_STRUCT
     VOID                    *ux_device_class_pima_application;
     VOID                    (*ux_device_class_pima_instance_activate)(VOID *);
     VOID                    (*ux_device_class_pima_instance_deactivate)(VOID *);
-    
-                                                                
+
+
 } UX_SLAVE_CLASS_PIMA;
 
 /* Define PIMA endpoint buffer settings (when PIMA owns buffer).  */
@@ -944,14 +948,14 @@ typedef struct UX_SLAVE_CLASS_PIMA_PARAMETER_STRUCT
     UINT                    (*ux_device_class_pima_parameter_storage_format)(struct UX_SLAVE_CLASS_PIMA_STRUCT *pima, ULONG storage_id);
     UINT                    (*ux_device_class_pima_parameter_storage_info_get)(struct UX_SLAVE_CLASS_PIMA_STRUCT *pima, ULONG storage_id);
     UINT                    (*ux_device_class_pima_parameter_object_number_get)(struct UX_SLAVE_CLASS_PIMA_STRUCT *pima, ULONG object_format_code, ULONG object_association, ULONG *object_number);
-    UINT                    (*ux_device_class_pima_parameter_object_handles_get)(struct UX_SLAVE_CLASS_PIMA_STRUCT *pima, ULONG object_handles_format_code, 
-                                                                        ULONG object_handles_association, 
+    UINT                    (*ux_device_class_pima_parameter_object_handles_get)(struct UX_SLAVE_CLASS_PIMA_STRUCT *pima, ULONG object_handles_format_code,
+                                                                        ULONG object_handles_association,
                                                                         ULONG *object_handles_array,
                                                                         ULONG object_handles_max_number);
     UINT                    (*ux_device_class_pima_parameter_object_info_get)(struct UX_SLAVE_CLASS_PIMA_STRUCT *pima, ULONG object_handle, UX_SLAVE_CLASS_PIMA_OBJECT **object);
     UINT                    (*ux_device_class_pima_parameter_object_data_get)(struct UX_SLAVE_CLASS_PIMA_STRUCT *pima, ULONG object_handle, UCHAR *object_buffer, ULONG object_offset,
                                                                 ULONG object_length_requested, ULONG *object_actual_length);
-                                                                        
+
     UINT                    (*ux_device_class_pima_parameter_object_info_send)(struct UX_SLAVE_CLASS_PIMA_STRUCT *pima, UX_SLAVE_CLASS_PIMA_OBJECT *object, ULONG storage_id, ULONG parent_object_handle, ULONG *object_handle);
     UINT                    (*ux_device_class_pima_parameter_object_data_send)(struct UX_SLAVE_CLASS_PIMA_STRUCT *pima, ULONG object_handle, ULONG phase ,UCHAR *object_buffer, ULONG object_offset,
                                                                 ULONG object_length);
@@ -970,7 +974,7 @@ typedef struct UX_SLAVE_CLASS_PIMA_PARAMETER_STRUCT
 /* Define PIMA Object decompaction structure.  */
 
 #define UX_DEVICE_CLASS_PIMA_OBJECT_MAX_LENGTH                              512
-#define UX_DEVICE_CLASS_PIMA_OBJECT_VARIABLE_OFFSET                         52  
+#define UX_DEVICE_CLASS_PIMA_OBJECT_VARIABLE_OFFSET                         52
 #define UX_DEVICE_CLASS_PIMA_OBJECT_ENTRIES                                 15
 
 
@@ -980,12 +984,12 @@ typedef struct UX_SLAVE_CLASS_PIMA_PARAMETER_STRUCT
 #define UX_DEVICE_CLASS_PIMA_STORAGE_FILE_SYSTEM_TYPE                       (UX_DEVICE_CLASS_PIMA_DATA_HEADER_SIZE + 2 )
 #define UX_DEVICE_CLASS_PIMA_STORAGE_ACCESS_CAPABILITY                      (UX_DEVICE_CLASS_PIMA_DATA_HEADER_SIZE + 4 )
 #define UX_DEVICE_CLASS_PIMA_STORAGE_MAX_CAPACITY_LOW                       (UX_DEVICE_CLASS_PIMA_DATA_HEADER_SIZE + 6 )
-#define UX_DEVICE_CLASS_PIMA_STORAGE_MAX_CAPACITY_HIGH                      (UX_DEVICE_CLASS_PIMA_DATA_HEADER_SIZE + 10) 
+#define UX_DEVICE_CLASS_PIMA_STORAGE_MAX_CAPACITY_HIGH                      (UX_DEVICE_CLASS_PIMA_DATA_HEADER_SIZE + 10)
 #define UX_DEVICE_CLASS_PIMA_STORAGE_FREE_SPACE_LOW                         (UX_DEVICE_CLASS_PIMA_DATA_HEADER_SIZE + 14)
-#define UX_DEVICE_CLASS_PIMA_STORAGE_FREE_SPACE_HIGH                        (UX_DEVICE_CLASS_PIMA_DATA_HEADER_SIZE + 18) 
+#define UX_DEVICE_CLASS_PIMA_STORAGE_FREE_SPACE_HIGH                        (UX_DEVICE_CLASS_PIMA_DATA_HEADER_SIZE + 18)
 #define UX_DEVICE_CLASS_PIMA_STORAGE_FREE_SPACE_IMAGE                       (UX_DEVICE_CLASS_PIMA_DATA_HEADER_SIZE + 22)
 #define UX_DEVICE_CLASS_PIMA_STORAGE_FREE_STORAGE_DESCRIPTION               (UX_DEVICE_CLASS_PIMA_DATA_HEADER_SIZE + 26)
- 
+
 /* Define Pima Class function prototypes.  */
 UINT  _ux_device_class_pima_initialize(UX_SLAVE_CLASS_COMMAND *command);
 UINT  _ux_device_class_pima_activate(UX_SLAVE_CLASS_COMMAND *command);
@@ -993,16 +997,17 @@ UINT  _ux_device_class_pima_deactivate(UX_SLAVE_CLASS_COMMAND *command);
 UINT  _ux_device_class_pima_control_request(UX_SLAVE_CLASS_COMMAND *command);
 UINT  _ux_device_class_pima_device_info_send(UX_SLAVE_CLASS_PIMA *pima);
 UINT  _ux_device_class_pima_entry(UX_SLAVE_CLASS_COMMAND *command);
-UINT  _ux_device_class_pima_event_get(UX_SLAVE_CLASS_PIMA *pima, 
+UINT  _ux_device_class_pima_uninitialize(UX_SLAVE_CLASS_COMMAND *command);
+UINT  _ux_device_class_pima_event_get(UX_SLAVE_CLASS_PIMA *pima,
                                       UX_SLAVE_CLASS_PIMA_EVENT *pima_event);
-UINT  _ux_device_class_pima_event_set(UX_SLAVE_CLASS_PIMA *pima, 
+UINT  _ux_device_class_pima_event_set(UX_SLAVE_CLASS_PIMA *pima,
                                       UX_SLAVE_CLASS_PIMA_EVENT *pima_event);
 VOID  _ux_device_class_pima_interrupt_thread(ULONG pima_class);
-UINT  _ux_device_class_pima_response_send(UX_SLAVE_CLASS_PIMA *pima, ULONG response_code, 
-                                            ULONG number_parameters, 
+UINT  _ux_device_class_pima_response_send(UX_SLAVE_CLASS_PIMA *pima, ULONG response_code,
+                                            ULONG number_parameters,
                                             ULONG parameter_1, ULONG parameter_2, ULONG paramater_3);
 VOID  _ux_device_class_pima_thread(ULONG pima_class);
-UINT  _ux_device_class_pima_object_handles_send(UX_SLAVE_CLASS_PIMA *pima, 
+UINT  _ux_device_class_pima_object_handles_send(UX_SLAVE_CLASS_PIMA *pima,
                                                     ULONG storage_id,
                                                     ULONG object_format_code,
                                                     ULONG object_association);
@@ -1020,9 +1025,9 @@ UINT  _ux_device_class_pima_object_data_get(UX_SLAVE_CLASS_PIMA *pima, ULONG obj
 UINT  _ux_device_class_pima_object_data_send(UX_SLAVE_CLASS_PIMA *pima);
 UINT  _ux_device_class_pima_object_delete(UX_SLAVE_CLASS_PIMA *pima, ULONG object_handle, ULONG object_format);
 UINT  _ux_device_class_pima_object_add(UX_SLAVE_CLASS_PIMA *pima, ULONG object_handle);
-UINT  _ux_device_class_pima_partial_object_data_get(UX_SLAVE_CLASS_PIMA *pima, 
-                                                    ULONG object_handle, 
-                                                    ULONG offset_requested, 
+UINT  _ux_device_class_pima_partial_object_data_get(UX_SLAVE_CLASS_PIMA *pima,
+                                                    ULONG object_handle,
+                                                    ULONG offset_requested,
                                                     ULONG length_requested);
 
 UINT  _ux_device_class_pima_storage_id_send(UX_SLAVE_CLASS_PIMA *pima);
@@ -1060,13 +1065,13 @@ UINT  _uxe_device_class_pima_initialize(UX_SLAVE_CLASS_COMMAND *command);
 #define ux_device_class_pima_initialize         _ux_device_class_pima_initialize
 #define ux_device_class_pima_activate           _ux_device_class_pima_activate
 #define ux_device_class_pima_dectivate          _ux_device_class_pima_dectivate
-#define ux_device_class_pima_entry              _ux_device_class_pima_entry   
+#define ux_device_class_pima_entry              _ux_device_class_pima_entry
 #define ux_device_class_pima_control_request    _ux_device_class_pima_control_request
 #define ux_device_class_pima_object_add         _ux_device_class_pima_object_add
 
 /* Define Pima Class data prototypes.  */
 
-extern UCHAR  _ux_device_class_pima_vendor_extension_descriptor[]; 
+extern UCHAR  _ux_device_class_pima_vendor_extension_descriptor[];
 extern USHORT _ux_device_class_pima_supported_operations[];
 extern USHORT _ux_device_class_pima_supported_events[];
 extern USHORT _ux_device_class_pima_supported_capture_formats[];
@@ -1075,10 +1080,10 @@ extern USHORT _ux_device_class_pima_device_prop_supported[];
 
 
 
-/* Determine if a C++ compiler is being used.  If so, complete the standard 
-   C conditional started above.  */   
+/* Determine if a C++ compiler is being used.  If so, complete the standard
+   C conditional started above.  */
 #ifdef __cplusplus
-} 
-#endif 
+}
+#endif
 
 #endif

--- a/common/usbx_device_classes/inc/ux_device_class_rndis.h
+++ b/common/usbx_device_classes/inc/ux_device_class_rndis.h
@@ -1,42 +1,42 @@
 /***************************************************************************
- * Copyright (c) 2024 Microsoft Corporation 
- * 
+ * Copyright (c) 2024 Microsoft Corporation
+ *
  * This program and the accompanying materials are made available under the
  * terms of the MIT License which is available at
  * https://opensource.org/licenses/MIT.
- * 
+ *
  * SPDX-License-Identifier: MIT
  **************************************************************************/
 
 /**************************************************************************/
 /**************************************************************************/
-/**                                                                       */ 
-/** USBX Component                                                        */ 
+/**                                                                       */
+/** USBX Component                                                        */
 /**                                                                       */
 /**   RNDIS Class                                                         */
 /**                                                                       */
 /**************************************************************************/
 /**************************************************************************/
 
-/**************************************************************************/ 
-/*                                                                        */ 
-/*  COMPONENT DEFINITION                                   RELEASE        */ 
-/*                                                                        */ 
-/*    ux_device_class_rndis.h                             PORTABLE C      */ 
-/*                                                           6.3.0        */
+/**************************************************************************/
+/*                                                                        */
+/*  COMPONENT DEFINITION                                   RELEASE        */
+/*                                                                        */
+/*    ux_device_class_rndis.h                             PORTABLE C      */
+/*                                                           6.x          */
 /*  AUTHOR                                                                */
 /*                                                                        */
 /*    Chaoqiong Xiao, Microsoft Corporation                               */
 /*                                                                        */
 /*  DESCRIPTION                                                           */
-/*                                                                        */ 
-/*    This file defines the equivalences for the USBX Device Class RNDIS  */ 
-/*    component.                                                          */ 
-/*                                                                        */ 
-/*  RELEASE HISTORY                                                       */ 
-/*                                                                        */ 
-/*    DATE              NAME                      DESCRIPTION             */ 
-/*                                                                        */ 
+/*                                                                        */
+/*    This file defines the equivalences for the USBX Device Class RNDIS  */
+/*    component.                                                          */
+/*                                                                        */
+/*  RELEASE HISTORY                                                       */
+/*                                                                        */
+/*    DATE              NAME                      DESCRIPTION             */
+/*                                                                        */
 /*  05-19-2020     Chaoqiong Xiao           Initial Version 6.0           */
 /*  09-30-2020     Chaoqiong Xiao           Modified comment(s),          */
 /*                                            used UX prefix to refer to  */
@@ -60,21 +60,25 @@
 /*                                            endpoint buffer in classes, */
 /*                                            improved error checking,    */
 /*                                            resulting in version 6.3.0  */
+/*  xx-xx-xxxx     Mohamed ayed             Modified comment(s),          */
+/*                                            added rndis deinit function,*/
+/*                                            remove extra spaces,        */
+/*                                            resulting in version 6.x    */
 /*                                                                        */
 /**************************************************************************/
 
 #ifndef UX_DEVICE_CLASS_RNDIS_H
 #define UX_DEVICE_CLASS_RNDIS_H
 
-/* Determine if a C++ compiler is being used.  If so, ensure that standard 
-   C is used to process the API information.  */ 
+/* Determine if a C++ compiler is being used.  If so, ensure that standard
+   C is used to process the API information.  */
 
-#ifdef   __cplusplus 
+#ifdef   __cplusplus
 
-/* Yes, C++ compiler is present.  Use standard C.  */ 
-extern   "C" { 
+/* Yes, C++ compiler is present.  Use standard C.  */
+extern   "C" {
 
-#endif  
+#endif
 
 
 /* Option: defined, it enables zero copy support (works if HID owns endpoint buffer).
@@ -141,9 +145,9 @@ VOID  _ux_network_driver_link_down(VOID *ux_network_handle);
 #define UX_DEVICE_CLASS_RNDIS_ETHERNET_IP                                       0x0800
 #define UX_DEVICE_CLASS_RNDIS_ETHERNET_ARP                                      0x0806
 #define UX_DEVICE_CLASS_RNDIS_ETHERNET_RARP                                     0x8035
-#define UX_DEVICE_CLASS_RNDIS_ETHERNET_PACKET_SIZE                              1536    
+#define UX_DEVICE_CLASS_RNDIS_ETHERNET_PACKET_SIZE                              1536
 #define UX_DEVICE_CLASS_RNDIS_NX_ALIGN_PADDING                                  2
-#define UX_DEVICE_CLASS_RNDIS_NX_PKPOOL_ENTRIES                                 8  
+#define UX_DEVICE_CLASS_RNDIS_NX_PKPOOL_ENTRIES                                 8
 
 #define UX_DEVICE_CLASS_RNDIS_NX_PACKET_SIZE                                    sizeof(NX_PACKET)
 
@@ -171,10 +175,10 @@ VOID  _ux_network_driver_link_down(VOID *ux_network_handle);
 #define UX_DEVICE_CLASS_RNDIS_NX_ETHERNET_POOL_ALLOCSIZE                        (UX_DEVICE_CLASS_RNDIS_NX_PKPOOL_ENTRIES * UX_DEVICE_CLASS_RNDIS_NX_BUFF_SIZE + 32)
 
 #define UX_DEVICE_CLASS_RNDIS_ETHERNET_SIZE                                     14
-#define UX_DEVICE_CLASS_RNDIS_NODE_ID_LENGTH                                    6  
-#define UX_DEVICE_CLASS_RNDIS_VENDOR_DESCRIPTION_MAX_LENGTH                     64  
+#define UX_DEVICE_CLASS_RNDIS_NODE_ID_LENGTH                                    6
+#define UX_DEVICE_CLASS_RNDIS_VENDOR_DESCRIPTION_MAX_LENGTH                     64
 #define UX_DEVICE_CLASS_RNDIS_MAC_OPTIONS                                       8
-#define UX_DEVICE_CLASS_RNDIS_PACKET_HEADER_MSG                                 1 
+#define UX_DEVICE_CLASS_RNDIS_PACKET_HEADER_MSG                                 1
 
 #define UX_DEVICE_CLASS_RNDIS_OID_SUPPORTED_LIST_LENGTH                         30
 
@@ -509,7 +513,7 @@ VOID  _ux_network_driver_link_down(VOID *ux_network_handle);
 
 /* Define timeout packet allocation value.  */
 #ifndef UX_DEVICE_CLASS_RNDIS_PACKET_POOL_WAIT
-#define UX_DEVICE_CLASS_RNDIS_PACKET_POOL_WAIT                                  10  
+#define UX_DEVICE_CLASS_RNDIS_PACKET_POOL_WAIT                                  10
 #endif
 
 #ifndef UX_DEVICE_CLASS_RNDIS_PACKET_POOL_INST_WAIT
@@ -552,7 +556,7 @@ typedef struct UX_SLAVE_CLASS_RNDIS_PARAMETER_STRUCT
     NX_IP                   *ux_slave_class_rndis_parameter_nx_ip;
     ULONG                   ux_slave_class_rndis_parameter_nx_ip_address;
     ULONG                   ux_slave_class_rndis_parameter_nx_ip_network_mask;
-    
+
 } UX_SLAVE_CLASS_RNDIS_PARAMETER;
 
 /* Define RNDIS Class structure.  */
@@ -609,7 +613,7 @@ typedef struct UX_SLAVE_CLASS_RNDIS_STRUCT
 
     ULONG                                   ux_slave_class_rndis_link_state;
     VOID                                    *ux_slave_class_rndis_network_handle;
-    
+
 } UX_SLAVE_CLASS_RNDIS;
 
 /* Define RNDIS endpoint buffer settings (when RNDIS owns buffer).  */
@@ -631,14 +635,14 @@ typedef struct UX_SLAVE_CLASS_RNDIS_STRUCT
 
 /* Requests - Ethernet Networking Control Model */
 
-#define UX_DEVICE_CLASS_RNDIS_SEND_ENCAPSULATED_COMMAND                        0x00        
+#define UX_DEVICE_CLASS_RNDIS_SEND_ENCAPSULATED_COMMAND                        0x00
                                         /* Issues a command in the format of the supported control
                                            protocol. The intent of this mechanism is to support
                                            networking devices (e.g., host-based cable modems)
                                            that require an additional vendor-defined interface for
                                            media specific hardware configuration and
                                            management.  */
-#define UX_DEVICE_CLASS_RNDIS_GET_ENCAPSULATED_RESPONSE                        0x01        
+#define UX_DEVICE_CLASS_RNDIS_GET_ENCAPSULATED_RESPONSE                        0x01
                                         /* Requests a response in the format of the supported
                                            control protocol.  */
 
@@ -664,7 +668,7 @@ UINT  _ux_device_class_rndis_msg_keep_alive(UX_SLAVE_CLASS_RNDIS *rndis, UX_SLAV
 VOID  _ux_device_class_rndis_interrupt_thread(ULONG rndis_class);
 VOID  _ux_device_class_rndis_bulkin_thread(ULONG rndis_class);
 VOID  _ux_device_class_rndis_bulkout_thread(ULONG rndis_class);
-
+UINT  _ux_device_class_rndis_uninitialize(UX_SLAVE_CLASS_COMMAND *command);
 
 /* Define Device RNDIS Class API prototypes.  */
 
@@ -674,10 +678,10 @@ VOID  _ux_device_class_rndis_bulkout_thread(ULONG rndis_class);
 /* Define OID supported List.  */
 extern ULONG ux_device_class_rndis_oid_supported_list[];
 
-/* Determine if a C++ compiler is being used.  If so, complete the standard 
-   C conditional started above.  */   
+/* Determine if a C++ compiler is being used.  If so, complete the standard
+   C conditional started above.  */
 #ifdef __cplusplus
-} 
-#endif 
+}
+#endif
 
 #endif /* UX_DEVICE_CLASS_RNDIS_H */

--- a/common/usbx_device_classes/src/ux_device_class_audio_entry.c
+++ b/common/usbx_device_classes/src/ux_device_class_audio_entry.c
@@ -1,10 +1,10 @@
 /***************************************************************************
- * Copyright (c) 2024 Microsoft Corporation 
- * 
+ * Copyright (c) 2024 Microsoft Corporation
+ *
  * This program and the accompanying materials are made available under the
  * terms of the MIT License which is available at
  * https://opensource.org/licenses/MIT.
- * 
+ *
  * SPDX-License-Identifier: MIT
  **************************************************************************/
 
@@ -33,7 +33,7 @@
 /*  FUNCTION                                               RELEASE        */
 /*                                                                        */
 /*    _ux_device_class_audio_entry                        PORTABLE C      */
-/*                                                           6.2.1        */
+/*                                                           6.x          */
 /*  AUTHOR                                                                */
 /*                                                                        */
 /*    Chaoqiong Xiao, Microsoft Corporation                               */
@@ -79,6 +79,9 @@
 /*  03-08-2023     Chaoqiong Xiao           Modified comment(s),          */
 /*                                            added error checks support, */
 /*                                            resulting in version 6.2.1  */
+/*  xx-xx-xxxx     Mohamed ayed             Modified comment(s),          */
+/*                                            fix typo,                   */
+/*                                            resulting in version 6.x    */
 /*                                                                        */
 /**************************************************************************/
 UINT  _ux_device_class_audio_entry(UX_SLAVE_CLASS_COMMAND *command)
@@ -106,7 +109,7 @@ UINT        status;
 
     case UX_SLAVE_CLASS_COMMAND_UNINITIALIZE:
 
-        /* Call the init function of the Audio class.  */
+        /* Call the uninit function of the Audio class.  */
         status =  _ux_device_class_audio_uninitialize(command);
 
         /* Return the completion status.  */

--- a/common/usbx_device_classes/src/ux_device_class_ccid_entry.c
+++ b/common/usbx_device_classes/src/ux_device_class_ccid_entry.c
@@ -1,10 +1,10 @@
 /***************************************************************************
- * Copyright (c) 2024 Microsoft Corporation 
- * 
+ * Copyright (c) 2024 Microsoft Corporation
+ *
  * This program and the accompanying materials are made available under the
  * terms of the MIT License which is available at
  * https://opensource.org/licenses/MIT.
- * 
+ *
  * SPDX-License-Identifier: MIT
  **************************************************************************/
 
@@ -33,7 +33,7 @@
 /*  FUNCTION                                               RELEASE        */
 /*                                                                        */
 /*    _ux_device_class_ccid_entry                         PORTABLE C      */
-/*                                                           6.1.11       */
+/*                                                           6.x          */
 /*  AUTHOR                                                                */
 /*                                                                        */
 /*    Chaoqiong Xiao, Microsoft Corporation                               */
@@ -70,6 +70,9 @@
 /*    DATE              NAME                      DESCRIPTION             */
 /*                                                                        */
 /*  04-25-2022     Chaoqiong Xiao           Initial Version 6.1.11        */
+/*  xx-xx-xxxx     Mohamed ayed             Modified comment(s),          */
+/*                                            fix typo,                   */
+/*                                            resulting in version 6.x    */
 /*                                                                        */
 /**************************************************************************/
 UINT  _ux_device_class_ccid_entry(UX_SLAVE_CLASS_COMMAND *command)
@@ -93,7 +96,7 @@ UINT        status;
 
     case UX_SLAVE_CLASS_COMMAND_UNINITIALIZE:
 
-        /* Call the init function of the CCID class.  */
+        /* Call the uninit function of the CCID class.  */
         status =  _ux_device_class_ccid_uninitialize(command);
 
         /* Return the completion status.  */

--- a/common/usbx_device_classes/src/ux_device_class_cdc_acm_entry.c
+++ b/common/usbx_device_classes/src/ux_device_class_cdc_acm_entry.c
@@ -1,17 +1,17 @@
 /***************************************************************************
- * Copyright (c) 2024 Microsoft Corporation 
- * 
+ * Copyright (c) 2024 Microsoft Corporation
+ *
  * This program and the accompanying materials are made available under the
  * terms of the MIT License which is available at
  * https://opensource.org/licenses/MIT.
- * 
+ *
  * SPDX-License-Identifier: MIT
  **************************************************************************/
 
 /**************************************************************************/
 /**************************************************************************/
-/**                                                                       */ 
-/** USBX Component                                                        */ 
+/**                                                                       */
+/** USBX Component                                                        */
 /**                                                                       */
 /**   Device CDC Class                                                    */
 /**                                                                       */
@@ -28,50 +28,54 @@
 #include "ux_device_stack.h"
 
 
-/**************************************************************************/ 
-/*                                                                        */ 
-/*  FUNCTION                                               RELEASE        */ 
-/*                                                                        */ 
-/*    _ux_device_class_cdc_acm_entry                      PORTABLE C      */ 
-/*                                                           6.1          */
+/**************************************************************************/
+/*                                                                        */
+/*  FUNCTION                                               RELEASE        */
+/*                                                                        */
+/*    _ux_device_class_cdc_acm_entry                      PORTABLE C      */
+/*                                                           6.x          */
 /*  AUTHOR                                                                */
 /*                                                                        */
 /*    Chaoqiong Xiao, Microsoft Corporation                               */
 /*                                                                        */
 /*  DESCRIPTION                                                           */
-/*                                                                        */ 
-/*    This function is the entry point of the cdc_acm class. It           */ 
-/*    will be called by the device stack enumeration module when the      */ 
+/*                                                                        */
+/*    This function is the entry point of the cdc_acm class. It           */
+/*    will be called by the device stack enumeration module when the      */
 /*    host has sent a SET_CONFIGURATION command and the cdc_acm interface */
 /*    needs to be mounted.                                                */
-/*                                                                        */ 
-/*  INPUT                                                                 */ 
-/*                                                                        */ 
-/*    command                               Pointer to class command      */ 
-/*                                                                        */ 
-/*  OUTPUT                                                                */ 
-/*                                                                        */ 
-/*    Completion Status                                                   */ 
-/*                                                                        */ 
-/*  CALLS                                                                 */ 
-/*                                                                        */ 
-/*    _ux_device_class_cdc_acm_initialize       Initialize cdc_acm class  */ 
-/*    _ux_device_class_cdc_acm_uninitialize     Uninitialize cdc_acm class*/ 
-/*    _ux_device_class_cdc_acm_activate         Activate cdc_acm class    */ 
-/*    _ux_device_class_cdc_acm_deactivate       Deactivate cdc_acm class  */ 
-/*    _ux_device_class_cdc_acm_control_request  Request control           */ 
-/*                                                                        */ 
-/*  CALLED BY                                                             */ 
-/*                                                                        */ 
+/*                                                                        */
+/*  INPUT                                                                 */
+/*                                                                        */
+/*    command                               Pointer to class command      */
+/*                                                                        */
+/*  OUTPUT                                                                */
+/*                                                                        */
+/*    Completion Status                                                   */
+/*                                                                        */
+/*  CALLS                                                                 */
+/*                                                                        */
+/*    _ux_device_class_cdc_acm_initialize       Initialize cdc_acm class  */
+/*    _ux_device_class_cdc_acm_uninitialize     Uninitialize cdc_acm class*/
+/*    _ux_device_class_cdc_acm_activate         Activate cdc_acm class    */
+/*    _ux_device_class_cdc_acm_deactivate       Deactivate cdc_acm class  */
+/*    _ux_device_class_cdc_acm_control_request  Request control           */
+/*                                                                        */
+/*  CALLED BY                                                             */
+/*                                                                        */
 /*    CDC Class                                                           */
-/*                                                                        */ 
-/*  RELEASE HISTORY                                                       */ 
-/*                                                                        */ 
-/*    DATE              NAME                      DESCRIPTION             */ 
-/*                                                                        */ 
+/*                                                                        */
+/*  RELEASE HISTORY                                                       */
+/*                                                                        */
+/*    DATE              NAME                      DESCRIPTION             */
+/*                                                                        */
 /*  05-19-2020     Chaoqiong Xiao           Initial Version 6.0           */
 /*  09-30-2020     Chaoqiong Xiao           Modified comment(s),          */
 /*                                            resulting in version 6.1    */
+/*  xx-xx-xxxx     Mohamed ayed             Modified comment(s),          */
+/*                                            fix typo,                   */
+/*                                            remove extra spaces,        */
+/*                                            resulting in version 6.x    */
 /*                                                                        */
 /**************************************************************************/
 UINT  _ux_device_class_cdc_acm_entry(UX_SLAVE_CLASS_COMMAND *command)
@@ -89,15 +93,15 @@ UINT        status;
 
         /* Call the init function of the CDC ACM class.  */
         status =  _ux_device_class_cdc_acm_initialize(command);
-        
+
         /* Return the completion status.  */
         return(status);
 
     case UX_SLAVE_CLASS_COMMAND_UNINITIALIZE:
 
-        /* Call the init function of the CDC ACM class.  */
+        /* Call the uninit function of the CDC ACM class.  */
         status =  _ux_device_class_cdc_acm_uninitialize(command);
-        
+
         /* Return the completion status.  */
         return(status);
 
@@ -124,7 +128,7 @@ UINT        status;
         /* The deactivate command is used when the device has been extracted.
            The device endpoints have to be dismounted and the cdc_acm thread canceled.  */
         status =  _ux_device_class_cdc_acm_deactivate(command);
-        
+
         /* Return the completion status.  */
         return(status);
 
@@ -136,13 +140,13 @@ UINT        status;
         /* Return the completion status.  */
         return(status);
 
-    default: 
+    default:
 
         /* If trace is enabled, insert this event into the trace buffer.  */
         UX_TRACE_IN_LINE_INSERT(UX_TRACE_ERROR, UX_FUNCTION_NOT_SUPPORTED, 0, 0, 0, UX_TRACE_ERRORS, 0, 0)
 
         /* Return an error.  */
         return(UX_FUNCTION_NOT_SUPPORTED);
-    }   
+    }
 }
 

--- a/common/usbx_device_classes/src/ux_device_class_cdc_ecm_entry.c
+++ b/common/usbx_device_classes/src/ux_device_class_cdc_ecm_entry.c
@@ -1,17 +1,17 @@
 /***************************************************************************
- * Copyright (c) 2024 Microsoft Corporation 
- * 
+ * Copyright (c) 2024 Microsoft Corporation
+ *
  * This program and the accompanying materials are made available under the
  * terms of the MIT License which is available at
  * https://opensource.org/licenses/MIT.
- * 
+ *
  * SPDX-License-Identifier: MIT
  **************************************************************************/
 
 /**************************************************************************/
 /**************************************************************************/
-/**                                                                       */ 
-/** USBX Component                                                        */ 
+/**                                                                       */
+/** USBX Component                                                        */
 /**                                                                       */
 /**   Device CDC_ECM Class                                                */
 /**                                                                       */
@@ -28,51 +28,55 @@
 #include "ux_device_stack.h"
 
 
-/**************************************************************************/ 
-/*                                                                        */ 
-/*  FUNCTION                                               RELEASE        */ 
-/*                                                                        */ 
-/*    _ux_device_class_cdc_ecm_entry                      PORTABLE C      */ 
-/*                                                           6.1          */
+/**************************************************************************/
+/*                                                                        */
+/*  FUNCTION                                               RELEASE        */
+/*                                                                        */
+/*    _ux_device_class_cdc_ecm_entry                      PORTABLE C      */
+/*                                                           6.x          */
 /*  AUTHOR                                                                */
 /*                                                                        */
 /*    Chaoqiong Xiao, Microsoft Corporation                               */
 /*                                                                        */
 /*  DESCRIPTION                                                           */
-/*                                                                        */ 
-/*    This function is the entry point of the cdc_ecm class. It           */ 
-/*    will be called by the device stack enumeration module when the      */ 
+/*                                                                        */
+/*    This function is the entry point of the cdc_ecm class. It           */
+/*    will be called by the device stack enumeration module when the      */
 /*    host has sent a SET_CONFIGURATION command and the cdc_ecm interface */
 /*    needs to be mounted.                                                */
-/*                                                                        */ 
-/*  INPUT                                                                 */ 
-/*                                                                        */ 
-/*    command                               Pointer to class command      */ 
-/*                                                                        */ 
-/*  OUTPUT                                                                */ 
-/*                                                                        */ 
-/*    Completion Status                                                   */ 
-/*                                                                        */ 
-/*  CALLS                                                                 */ 
-/*                                                                        */ 
+/*                                                                        */
+/*  INPUT                                                                 */
+/*                                                                        */
+/*    command                               Pointer to class command      */
+/*                                                                        */
+/*  OUTPUT                                                                */
+/*                                                                        */
+/*    Completion Status                                                   */
+/*                                                                        */
+/*  CALLS                                                                 */
+/*                                                                        */
 /*    _ux_device_class_cdc_ecm_initialize       Initialize cdc_ecm class  */
 /*    _ux_device_class_cdc_ecm_uninitialize     Uninitialize cdc_ecm class*/
-/*    _ux_device_class_cdc_ecm_activate         Activate cdc_ecm class    */ 
-/*    _ux_device_class_cdc_ecm_deactivate       Deactivate cdc_ecm class  */ 
+/*    _ux_device_class_cdc_ecm_activate         Activate cdc_ecm class    */
+/*    _ux_device_class_cdc_ecm_deactivate       Deactivate cdc_ecm class  */
 /*    _ux_device_class_cdc_ecm_change           Alternate setting change  */
-/*    _ux_device_class_cdc_ecm_control_request  Request control           */ 
-/*                                                                        */ 
-/*  CALLED BY                                                             */ 
-/*                                                                        */ 
+/*    _ux_device_class_cdc_ecm_control_request  Request control           */
+/*                                                                        */
+/*  CALLED BY                                                             */
+/*                                                                        */
 /*    CDC_ECM Class                                                       */
-/*                                                                        */ 
-/*  RELEASE HISTORY                                                       */ 
-/*                                                                        */ 
-/*    DATE              NAME                      DESCRIPTION             */ 
-/*                                                                        */ 
+/*                                                                        */
+/*  RELEASE HISTORY                                                       */
+/*                                                                        */
+/*    DATE              NAME                      DESCRIPTION             */
+/*                                                                        */
 /*  05-19-2020     Chaoqiong Xiao           Initial Version 6.0           */
 /*  09-30-2020     Chaoqiong Xiao           Modified comment(s),          */
 /*                                            resulting in version 6.1    */
+/*  xx-xx-xxxx     Mohamed ayed             Modified comment(s),          */
+/*                                            fix typo,                   */
+/*                                            remove extra spaces,        */
+/*                                            resulting in version 6.x    */
 /*                                                                        */
 /**************************************************************************/
 UINT  _ux_device_class_cdc_ecm_entry(UX_SLAVE_CLASS_COMMAND *command)
@@ -89,22 +93,22 @@ UINT        status;
 
         /* Call the init function of the CDC_ECM class.  */
         status =  _ux_device_class_cdc_ecm_initialize(command);
-        
+
         /* Return the completion status.  */
         return(status);
 
     case UX_SLAVE_CLASS_COMMAND_UNINITIALIZE:
 
-        /* Call the init function of the CDC_ECM class.  */
+        /* Call the uninit function of the CDC_ECM class.  */
         status =  _ux_device_class_cdc_ecm_uninitialize(command);
-        
+
         /* Return the completion status.  */
         return(status);
 
     case UX_SLAVE_CLASS_COMMAND_QUERY:
 
         /* Check the CLASS definition in the interface descriptor. */
-        if (command -> ux_slave_class_command_class == UX_DEVICE_CLASS_CDC_ECM_CLASS_COMMUNICATION_CONTROL || 
+        if (command -> ux_slave_class_command_class == UX_DEVICE_CLASS_CDC_ECM_CLASS_COMMUNICATION_CONTROL ||
                 command -> ux_slave_class_command_class == UX_DEVICE_CLASS_CDC_ECM_CLASS_COMMUNICATION_DATA)
             return(UX_SUCCESS);
         else
@@ -113,13 +117,13 @@ UINT        status;
     case UX_SLAVE_CLASS_COMMAND_ACTIVATE:
 
         /* The activate command is used when the host has sent a SET_CONFIGURATION command
-           and this interface has to be mounted. In CDC ECM, the alternate setting 0 has no endpoints.  
+           and this interface has to be mounted. In CDC ECM, the alternate setting 0 has no endpoints.
            Only the Alternate Setting 1 has the Bulk IN and OUT endpoints active.  */
         status =  _ux_device_class_cdc_ecm_activate(command);
 
         /* Return the completion status.  */
         return(status);
-        
+
     case UX_SLAVE_CLASS_COMMAND_CHANGE:
 
         /* The change command is used when the host has sent a SET_INTERFACE command
@@ -128,14 +132,14 @@ UINT        status;
 
         /* Return the completion status.  */
         return(status);
-        
+
 
     case UX_SLAVE_CLASS_COMMAND_DEACTIVATE:
 
         /* The deactivate command is used when the device has been extracted.
            The device endpoints have to be dismounted and the cdc_ecm thread canceled.  */
         status =  _ux_device_class_cdc_ecm_deactivate(command);
-        
+
         /* Return the completion status.  */
         return(status);
 
@@ -147,7 +151,7 @@ UINT        status;
         /* Return the completion status.  */
         return(status);
 
-    default: 
+    default:
 
         /* Error trap. */
         _ux_system_error_handler(UX_SYSTEM_LEVEL_THREAD, UX_SYSTEM_CONTEXT_CLASS, UX_FUNCTION_NOT_SUPPORTED);
@@ -157,6 +161,6 @@ UINT        status;
 
         /* Return an error.  */
         return(UX_FUNCTION_NOT_SUPPORTED);
-    }   
+    }
 }
 

--- a/common/usbx_device_classes/src/ux_device_class_cdc_ecm_uninitialize.c
+++ b/common/usbx_device_classes/src/ux_device_class_cdc_ecm_uninitialize.c
@@ -46,7 +46,7 @@
 /*                                                                        */ 
 /*  INPUT                                                                 */ 
 /*                                                                        */ 
-/*    command                               Pointer to storage command    */ 
+/*    command                               Pointer to cdc ecm command    */
 /*                                                                        */ 
 /*  OUTPUT                                                                */ 
 /*                                                                        */ 

--- a/common/usbx_device_classes/src/ux_device_class_dfu_entry.c
+++ b/common/usbx_device_classes/src/ux_device_class_dfu_entry.c
@@ -1,17 +1,17 @@
 /***************************************************************************
- * Copyright (c) 2024 Microsoft Corporation 
- * 
+ * Copyright (c) 2024 Microsoft Corporation
+ *
  * This program and the accompanying materials are made available under the
  * terms of the MIT License which is available at
  * https://opensource.org/licenses/MIT.
- * 
+ *
  * SPDX-License-Identifier: MIT
  **************************************************************************/
 
 /**************************************************************************/
 /**************************************************************************/
-/**                                                                       */ 
-/** USBX Component                                                        */ 
+/**                                                                       */
+/** USBX Component                                                        */
 /**                                                                       */
 /**   Device DFU Class                                                    */
 /**                                                                       */
@@ -28,52 +28,58 @@
 #include "ux_device_stack.h"
 
 
-/**************************************************************************/ 
-/*                                                                        */ 
-/*  FUNCTION                                               RELEASE        */ 
-/*                                                                        */ 
-/*    _ux_device_class_dfu_entry                          PORTABLE C      */ 
-/*                                                           6.3.0        */
+/**************************************************************************/
+/*                                                                        */
+/*  FUNCTION                                               RELEASE        */
+/*                                                                        */
+/*    _ux_device_class_dfu_entry                          PORTABLE C      */
+/*                                                           6.x          */
 /*  AUTHOR                                                                */
 /*                                                                        */
 /*    Chaoqiong Xiao, Microsoft Corporation                               */
 /*                                                                        */
 /*  DESCRIPTION                                                           */
-/*                                                                        */ 
-/*    This function is the entry point of the dfu class. It               */ 
-/*    will be called by the device stack enumeration module when the      */ 
+/*                                                                        */
+/*    This function is the entry point of the dfu class. It               */
+/*    will be called by the device stack enumeration module when the      */
 /*    host has sent a SET_CONFIGURATION command and the dfu interface     */
 /*    needs to be mounted.                                                */
-/*                                                                        */ 
-/*  INPUT                                                                 */ 
-/*                                                                        */ 
-/*    command                               Pointer to class command      */ 
-/*                                                                        */ 
-/*  OUTPUT                                                                */ 
-/*                                                                        */ 
-/*    Completion Status                                                   */ 
-/*                                                                        */ 
-/*  CALLS                                                                 */ 
-/*                                                                        */ 
+/*                                                                        */
+/*  INPUT                                                                 */
+/*                                                                        */
+/*    command                               Pointer to class command      */
+/*                                                                        */
+/*  OUTPUT                                                                */
+/*                                                                        */
+/*    Completion Status                                                   */
+/*                                                                        */
+/*  CALLS                                                                 */
+/*                                                                        */
 /*    _ux_device_class_dfu_initialize       Initialize dfu class          */
-/*    _ux_device_class_dfu_activate         Activate dfu class            */ 
-/*    _ux_device_class_dfu_deactivate       Deactivate dfu class          */ 
-/*    _ux_device_class_dfu_control_request  Request control               */ 
-/*                                                                        */ 
-/*  CALLED BY                                                             */ 
-/*                                                                        */ 
+/*    _ux_device_class_dfu_uninitialize     Uninitialize dfu class        */
+/*    _ux_device_class_dfu_activate         Activate dfu class            */
+/*    _ux_device_class_dfu_deactivate       Deactivate dfu class          */
+/*    _ux_device_class_dfu_control_request  Request control               */
+/*                                                                        */
+/*  CALLED BY                                                             */
+/*                                                                        */
 /*    DFU Class                                                           */
-/*                                                                        */ 
-/*  RELEASE HISTORY                                                       */ 
-/*                                                                        */ 
-/*    DATE              NAME                      DESCRIPTION             */ 
-/*                                                                        */ 
+/*                                                                        */
+/*  RELEASE HISTORY                                                       */
+/*                                                                        */
+/*    DATE              NAME                      DESCRIPTION             */
+/*                                                                        */
 /*  05-19-2020     Chaoqiong Xiao           Initial Version 6.0           */
 /*  09-30-2020     Chaoqiong Xiao           Modified comment(s),          */
 /*                                            resulting in version 6.1    */
 /*  10-31-2023     Yajun Xia                Modified comment(s),          */
 /*                                            added error checks support, */
 /*                                            resulting in version 6.3.0  */
+/*  xx-xx-xxxx     Mohamed ayed             Modified comment(s),          */
+/*                                            added call of dfu uninit    */
+/*                                            function,                   */
+/*                                            remove extra spaces,        */
+/*                                            resulting in version 6.x    */
 /*                                                                        */
 /**************************************************************************/
 UINT  _ux_device_class_dfu_entry(UX_SLAVE_CLASS_COMMAND *command)
@@ -90,17 +96,24 @@ UINT        status;
     case UX_SLAVE_CLASS_COMMAND_INITIALIZE:
 #ifdef UX_DEVICE_CLASS_DFU_ENABLE_ERROR_CHECKING
 
-        /* Call the init function of the DFU ACM class.  */
+        /* Call the init function of the DFU class.  */
         status =  _uxe_device_class_dfu_initialize(command);
 #else
 
-        /* Call the init function of the DFU ACM class.  */
+        /* Call the init function of the DFU class.  */
         status =  _ux_device_class_dfu_initialize(command);
 #endif /* UX_DEVICE_CLASS_DFU_ENABLE_ERROR_CHECKING */
 
         /* Return the completion status.  */
         return(status);
 
+    case UX_SLAVE_CLASS_COMMAND_UNINITIALIZE:
+
+        /* Call the uninit function of the DFU class.  */
+        status =  _ux_device_class_dfu_uninitialize(command);
+
+        /* Return the completion status.  */
+        return(status);
 
     case UX_SLAVE_CLASS_COMMAND_QUERY:
 
@@ -125,7 +138,7 @@ UINT        status;
         /* The deactivate command is used when the device has been extracted.
            The device endpoints have to be dismounted and the dfu thread canceled.  */
         status =  _ux_device_class_dfu_deactivate(command);
-        
+
         /* Return the completion status.  */
         return(status);
 
@@ -137,13 +150,13 @@ UINT        status;
         /* Return the completion status.  */
         return(status);
 
-    default: 
+    default:
 
         /* If trace is enabled, insert this event into the trace buffer.  */
         UX_TRACE_IN_LINE_INSERT(UX_TRACE_ERROR, UX_FUNCTION_NOT_SUPPORTED, 0, 0, 0, UX_TRACE_ERRORS, 0, 0)
 
         /* Return an error.  */
         return(UX_FUNCTION_NOT_SUPPORTED);
-    }   
+    }
 }
 

--- a/common/usbx_device_classes/src/ux_device_class_dfu_uninitialize.c
+++ b/common/usbx_device_classes/src/ux_device_class_dfu_uninitialize.c
@@ -12,7 +12,7 @@
 /**                                                                       */
 /** USBX Component                                                        */
 /**                                                                       */
-/**   Device HID Class                                                    */
+/**   Device DFU Class                                                    */
 /**                                                                       */
 /**************************************************************************/
 /**************************************************************************/
@@ -23,7 +23,7 @@
 /* Include necessary system files.  */
 
 #include "ux_api.h"
-#include "ux_device_class_hid.h"
+#include "ux_device_class_dfu.h"
 #include "ux_device_stack.h"
 
 
@@ -31,7 +31,7 @@
 /*                                                                        */
 /*  FUNCTION                                               RELEASE        */
 /*                                                                        */
-/*    _ux_device_class_hid_uninitialize                   PORTABLE C      */
+/*    _ux_device_class_dfu_uninitialize                   PORTABLE C      */
 /*                                                           6.x          */
 /*  AUTHOR                                                                */
 /*                                                                        */
@@ -39,11 +39,11 @@
 /*                                                                        */
 /*  DESCRIPTION                                                           */
 /*                                                                        */
-/*    This function uninitializes the USB HID device.                     */
+/*    This function uninitializes the USB DFU device.                     */
 /*                                                                        */
 /*  INPUT                                                                 */
 /*                                                                        */
-/*    command                              Pointer to hid command         */
+/*    command                              Pointer to dfu command         */
 /*                                                                        */
 /*  OUTPUT                                                                */
 /*                                                                        */
@@ -64,35 +64,13 @@
 /*                                                                        */
 /*    DATE              NAME                      DESCRIPTION             */
 /*                                                                        */
-/*  05-19-2020     Chaoqiong Xiao           Initial Version 6.0           */
-/*  09-30-2020     Chaoqiong Xiao           Modified comment(s),          */
-/*                                            resulting in version 6.1    */
-/*  01-31-2022     Chaoqiong Xiao           Modified comment(s),          */
-/*                                            added standalone support,   */
-/*                                            added interrupt OUT support,*/
-/*                                            resulting in version 6.1.10 */
-/*  04-25-2022     Chaoqiong Xiao           Modified comment(s),          */
-/*                                            resulting in version 6.1.11 */
-/*  07-29-2022     Chaoqiong Xiao           Modified comment(s),          */
-/*                                            fixed parameter/variable    */
-/*                                            names conflict C++ keyword, */
-/*                                            resulting in version 6.1.12 */
-/*  10-31-2023     Chaoqiong Xiao           Modified comment(s),          */
-/*                                            added zero copy support,    */
-/*                                            added a new mode to manage  */
-/*                                            endpoint buffer in classes, */
-/*                                            resulting in version 6.3.0  */
-/*  xx-xx-xxxx     Mohamed ayed             Modified comment(s),          */
-/*                                            added sanity check before   */
-/*                                            freed hid memory,           */
-/*                                            remove extra spaces,        */
-/*                                            resulting in version 6.x    */
+/*  xx-xx-xxxx     Mohamed ayed             Initial Version 6.x           */
 /*                                                                        */
 /**************************************************************************/
-UINT  _ux_device_class_hid_uninitialize(UX_SLAVE_CLASS_COMMAND *command)
+UINT  _ux_device_class_dfu_uninitialize(UX_SLAVE_CLASS_COMMAND *command)
 {
 
-UX_SLAVE_CLASS_HID                      *hid;
+UX_SLAVE_CLASS_DFU                      *dfu;
 UX_SLAVE_CLASS                          *class_ptr;
 
 
@@ -100,52 +78,24 @@ UX_SLAVE_CLASS                          *class_ptr;
     class_ptr =  command -> ux_slave_class_command_class_ptr;
 
     /* Get the class instance in the container.  */
-    hid = (UX_SLAVE_CLASS_HID *) class_ptr -> ux_slave_class_instance;
-
+    dfu = (UX_SLAVE_CLASS_DFU *) class_ptr -> ux_slave_class_instance;
 
     /* Sanity check.  */
-    if (hid != UX_NULL)
+    if (dfu != UX_NULL)
     {
 
 #if !defined(UX_DEVICE_STANDALONE)
 
-      /* Remove HID thread.  */
-      _ux_device_thread_delete(&class_ptr -> ux_slave_class_thread);
-
-      /* Remove the thread used by HID.  */
-      _ux_utility_memory_free(class_ptr -> ux_slave_class_thread_stack);
-
-      /* Delete the event flag group for the hid class.  */
-      _ux_device_event_flags_delete(&hid -> ux_device_class_hid_event_flags_group);
+        /* Free resources and return error.  */
+        _ux_device_thread_delete(&dfu -> ux_slave_class_dfu_thread);
+        _ux_utility_event_flags_delete(&dfu -> ux_slave_class_dfu_event_flags_group);
+        _ux_utility_memory_free(dfu -> ux_slave_class_dfu_thread_stack);
 #endif
 
-      /* Free memory for the array. */
-#if (UX_DEVICE_ENDPOINT_BUFFER_OWNER == 1) && defined(UX_DEVICE_CLASS_HID_ZERO_COPY)
-      _ux_utility_memory_free(hid -> ux_device_class_hid_event_array -> ux_device_class_hid_event_buffer);
-#endif
-      _ux_utility_memory_free(hid -> ux_device_class_hid_event_array);
-
-#if defined(UX_DEVICE_CLASS_HID_INTERRUPT_OUT_SUPPORT)
-
-#if !defined(UX_DEVICE_STANDALONE)
-
-      /* Free read mutex.  */
-      _ux_device_mutex_delete(&hid -> ux_device_class_hid_read_mutex);
-#endif
-
-      /* Uninitialize receiver.  */
-      if (hid -> ux_device_class_hid_receiver)
-        hid -> ux_device_class_hid_receiver ->
-          ux_device_class_hid_receiver_uninitialize(hid -> ux_device_class_hid_receiver);
-#endif
-
-#if defined(UX_DEVICE_CLASS_HID_OWN_ENDPOINT_BUFFER)
-      _ux_utility_memory_free(hid -> ux_device_class_hid_endpoint_buffer);
-#endif
-
-      /* Free the resources.  */
-      _ux_utility_memory_free(hid);
+        /* Free the resources.  */
+        _ux_utility_memory_free(dfu);
     }
+
     /* Return completion status.  */
     return(UX_SUCCESS);
 }

--- a/common/usbx_device_classes/src/ux_device_class_hid_entry.c
+++ b/common/usbx_device_classes/src/ux_device_class_hid_entry.c
@@ -1,17 +1,17 @@
 /***************************************************************************
- * Copyright (c) 2024 Microsoft Corporation 
- * 
+ * Copyright (c) 2024 Microsoft Corporation
+ *
  * This program and the accompanying materials are made available under the
  * terms of the MIT License which is available at
  * https://opensource.org/licenses/MIT.
- * 
+ *
  * SPDX-License-Identifier: MIT
  **************************************************************************/
 
 /**************************************************************************/
 /**************************************************************************/
-/**                                                                       */ 
-/** USBX Component                                                        */ 
+/**                                                                       */
+/** USBX Component                                                        */
 /**                                                                       */
 /**   Device HID Class                                                    */
 /**                                                                       */
@@ -26,55 +26,59 @@
 #include "ux_api.h"
 #include "ux_device_class_hid.h"
 #include "ux_device_stack.h"
- 
 
-/**************************************************************************/ 
-/*                                                                        */ 
-/*  FUNCTION                                               RELEASE        */ 
-/*                                                                        */ 
-/*    _ux_device_class_hid_entry                          PORTABLE C      */ 
-/*                                                           6.1          */
+
+/**************************************************************************/
+/*                                                                        */
+/*  FUNCTION                                               RELEASE        */
+/*                                                                        */
+/*    _ux_device_class_hid_entry                          PORTABLE C      */
+/*                                                           6.x          */
 /*  AUTHOR                                                                */
 /*                                                                        */
 /*    Chaoqiong Xiao, Microsoft Corporation                               */
 /*                                                                        */
 /*  DESCRIPTION                                                           */
-/*                                                                        */ 
-/*    This function is the entry point of the hid class. It               */ 
-/*    will be called by the device stack enumeration module when the      */ 
+/*                                                                        */
+/*    This function is the entry point of the hid class. It               */
+/*    will be called by the device stack enumeration module when the      */
 /*    host has sent a SET_CONFIGURATION command and the hid interface     */
 /*    needs to be mounted.                                                */
-/*                                                                        */ 
-/*  INPUT                                                                 */ 
-/*                                                                        */ 
-/*    command                               Pointer to class command      */ 
-/*                                                                        */ 
-/*  OUTPUT                                                                */ 
-/*                                                                        */ 
-/*    Completion Status                                                   */ 
-/*                                                                        */ 
-/*  CALLS                                                                 */ 
-/*                                                                        */ 
+/*                                                                        */
+/*  INPUT                                                                 */
+/*                                                                        */
+/*    command                               Pointer to class command      */
+/*                                                                        */
+/*  OUTPUT                                                                */
+/*                                                                        */
+/*    Completion Status                                                   */
+/*                                                                        */
+/*  CALLS                                                                 */
+/*                                                                        */
 /*    _ux_device_class_hid_initialize       Initialize hid class          */
 /*    _ux_device_class_hid_uninitialize     Uninitialize hid class        */
-/*    _ux_device_class_hid_activate         Activate hid class            */ 
-/*    _ux_device_class_hid_deactivate       Deactivate hid class          */ 
-/*    _ux_device_class_hid_control_request  Request control               */ 
-/*                                                                        */ 
-/*  CALLED BY                                                             */ 
-/*                                                                        */ 
+/*    _ux_device_class_hid_activate         Activate hid class            */
+/*    _ux_device_class_hid_deactivate       Deactivate hid class          */
+/*    _ux_device_class_hid_control_request  Request control               */
+/*                                                                        */
+/*  CALLED BY                                                             */
+/*                                                                        */
 /*    HID Class                                                           */
-/*                                                                        */ 
-/*  RELEASE HISTORY                                                       */ 
-/*                                                                        */ 
-/*    DATE              NAME                      DESCRIPTION             */ 
-/*                                                                        */ 
+/*                                                                        */
+/*  RELEASE HISTORY                                                       */
+/*                                                                        */
+/*    DATE              NAME                      DESCRIPTION             */
+/*                                                                        */
 /*  05-19-2020     Chaoqiong Xiao           Initial Version 6.0           */
 /*  09-30-2020     Chaoqiong Xiao           Modified comment(s),          */
 /*                                            resulting in version 6.1    */
 /*  10-31-2023     Chaoqiong Xiao           Modified comment(s),          */
 /*                                            added error checks support, */
 /*                                            resulting in version 6.3.0  */
+/*  xx-xx-xxxx     Mohamed ayed             Modified comment(s),          */
+/*                                            fix typo,                   */
+/*                                            remove extra spaces,        */
+/*                                            resulting in version 6.x    */
 /*                                                                        */
 /**************************************************************************/
 UINT  _ux_device_class_hid_entry(UX_SLAVE_CLASS_COMMAND *command)
@@ -102,9 +106,9 @@ UINT        status;
 
     case UX_SLAVE_CLASS_COMMAND_UNINITIALIZE:
 
-        /* Call the init function of the HID class.  */
+        /* Call the uninit function of the HID class.  */
         status =  _ux_device_class_hid_uninitialize(command);
-        
+
         /* Return the completion status.  */
         return(status);
 
@@ -131,7 +135,7 @@ UINT        status;
         /* The deactivate command is used when the device has been extracted.
            The device endpoints have to be dismounted and the hid thread canceled.  */
         status =  _ux_device_class_hid_deactivate(command);
-        
+
         /* Return the completion status.  */
         return(status);
 
@@ -143,13 +147,13 @@ UINT        status;
         /* Return the completion status.  */
         return(status);
 
-    default: 
+    default:
 
         /* If trace is enabled, insert this event into the trace buffer.  */
         UX_TRACE_IN_LINE_INSERT(UX_TRACE_ERROR, UX_FUNCTION_NOT_SUPPORTED, 0, 0, 0, UX_TRACE_ERRORS, 0, 0)
 
         /* Return an error.  */
         return(UX_FUNCTION_NOT_SUPPORTED);
-    }   
+    }
 }
 

--- a/common/usbx_device_classes/src/ux_device_class_pima_entry.c
+++ b/common/usbx_device_classes/src/ux_device_class_pima_entry.c
@@ -1,17 +1,17 @@
 /***************************************************************************
- * Copyright (c) 2024 Microsoft Corporation 
- * 
+ * Copyright (c) 2024 Microsoft Corporation
+ *
  * This program and the accompanying materials are made available under the
  * terms of the MIT License which is available at
  * https://opensource.org/licenses/MIT.
- * 
+ *
  * SPDX-License-Identifier: MIT
  **************************************************************************/
 
 /**************************************************************************/
 /**************************************************************************/
-/**                                                                       */ 
-/** USBX Component                                                        */ 
+/**                                                                       */
+/** USBX Component                                                        */
 /**                                                                       */
 /**   Device PIMA Class                                                   */
 /**                                                                       */
@@ -26,54 +26,60 @@
 #include "ux_api.h"
 #include "ux_device_class_pima.h"
 #include "ux_device_stack.h"
- 
 
-/**************************************************************************/ 
-/*                                                                        */ 
-/*  FUNCTION                                               RELEASE        */ 
-/*                                                                        */ 
-/*    _ux_device_class_pima_entry                         PORTABLE C      */ 
+
+/**************************************************************************/
+/*                                                                        */
+/*  FUNCTION                                               RELEASE        */
+/*                                                                        */
+/*    _ux_device_class_pima_entry                         PORTABLE C      */
 /*                                                           6.3.0        */
 /*  AUTHOR                                                                */
 /*                                                                        */
 /*    Chaoqiong Xiao, Microsoft Corporation                               */
 /*                                                                        */
 /*  DESCRIPTION                                                           */
-/*                                                                        */ 
-/*    This function is the entry point of the pima class. It              */ 
-/*    will be called by the device stack enumeration module when the      */ 
+/*                                                                        */
+/*    This function is the entry point of the pima class. It              */
+/*    will be called by the device stack enumeration module when the      */
 /*    host has sent a SET_CONFIGURATION command and the pima interface    */
 /*    needs to be mounted.                                                */
-/*                                                                        */ 
-/*  INPUT                                                                 */ 
-/*                                                                        */ 
-/*    command                               Pointer to class command      */ 
-/*                                                                        */ 
-/*  OUTPUT                                                                */ 
-/*                                                                        */ 
-/*    Completion Status                                                   */ 
-/*                                                                        */ 
-/*  CALLS                                                                 */ 
-/*                                                                        */ 
+/*                                                                        */
+/*  INPUT                                                                 */
+/*                                                                        */
+/*    command                               Pointer to class command      */
+/*                                                                        */
+/*  OUTPUT                                                                */
+/*                                                                        */
+/*    Completion Status                                                   */
+/*                                                                        */
+/*  CALLS                                                                 */
+/*                                                                        */
 /*    _ux_device_class_pima_initialize       Initialize pima class        */
-/*    _ux_device_class_pima_activate         Activate pima class          */ 
-/*    _ux_device_class_pima_deactivate       Deactivate pima class        */ 
-/*    _ux_device_class_pima_control_request  Request control              */ 
-/*                                                                        */ 
-/*  CALLED BY                                                             */ 
-/*                                                                        */ 
+/*    _ux_device_class_pima_uninitialize     Uninitialize pima class      */
+/*    _ux_device_class_pima_activate         Activate pima class          */
+/*    _ux_device_class_pima_deactivate       Deactivate pima class        */
+/*    _ux_device_class_pima_control_request  Request control              */
+/*                                                                        */
+/*  CALLED BY                                                             */
+/*                                                                        */
 /*    PIMA Class                                                          */
-/*                                                                        */ 
-/*  RELEASE HISTORY                                                       */ 
-/*                                                                        */ 
-/*    DATE              NAME                      DESCRIPTION             */ 
-/*                                                                        */ 
+/*                                                                        */
+/*  RELEASE HISTORY                                                       */
+/*                                                                        */
+/*    DATE              NAME                      DESCRIPTION             */
+/*                                                                        */
 /*  05-19-2020     Chaoqiong Xiao           Initial Version 6.0           */
 /*  09-30-2020     Chaoqiong Xiao           Modified comment(s),          */
 /*                                            resulting in version 6.1    */
 /*  10-31-2023     Chaoqiong Xiao           Modified comment(s),          */
 /*                                            added error checks support, */
 /*                                            resulting in version 6.3.0  */
+/*  xx-xx-xxxx     Mohamed ayed             Modified comment(s),          */
+/*                                            added call of pima uninit   */
+/*                                            function,                   */
+/*                                            remove extra spaces,        */
+/*                                            resulting in version 6.x    */
 /*                                                                        */
 /**************************************************************************/
 UINT  _ux_device_class_pima_entry(UX_SLAVE_CLASS_COMMAND *command)
@@ -95,7 +101,15 @@ UINT        status;
 #else
         status =  _ux_device_class_pima_initialize(command);
 #endif
-        
+
+        /* Return the completion status.  */
+        return(status);
+
+    case UX_SLAVE_CLASS_COMMAND_UNINITIALIZE:
+
+        /* Call the uninit function of the PIMA class.  */
+        status =  _ux_device_class_pima_uninitialize(command);
+
         /* Return the completion status.  */
         return(status);
 
@@ -122,7 +136,7 @@ UINT        status;
         /* The deactivate command is used when the device has been extracted.
            The device endpoints have to be dismounted and the pima thread canceled.  */
         status =  _ux_device_class_pima_deactivate(command);
-        
+
         /* Return the completion status.  */
         return(status);
 
@@ -134,13 +148,13 @@ UINT        status;
         /* Return the completion status.  */
         return(status);
 
-    default: 
+    default:
 
         /* If trace is enabled, insert this event into the trace buffer.  */
         UX_TRACE_IN_LINE_INSERT(UX_TRACE_ERROR, UX_FUNCTION_NOT_SUPPORTED, 0, 0, 0, UX_TRACE_ERRORS, 0, 0)
 
         /* Return an error.  */
         return(UX_FUNCTION_NOT_SUPPORTED);
-    }   
+    }
 }
 

--- a/common/usbx_device_classes/src/ux_device_class_pima_uninitialize.c
+++ b/common/usbx_device_classes/src/ux_device_class_pima_uninitialize.c
@@ -1,0 +1,116 @@
+/***************************************************************************
+* Copyright (c) 2024 Microsoft Corporation
+*
+* This program and the accompanying materials are made available under the
+* terms of the MIT License which is available at
+* https://opensource.org/licenses/MIT.
+*
+* SPDX-License-Identifier: MIT
+**************************************************************************/
+
+/**************************************************************************/
+/**                                                                       */
+/** USBX Component                                                        */
+/**                                                                       */
+/**   Device PIMA Class                                                   */
+/**                                                                       */
+/**************************************************************************/
+/**************************************************************************/
+
+#define UX_SOURCE_CODE
+
+
+/* Include necessary system files.  */
+
+#include "ux_api.h"
+#include "ux_device_class_pima.h"
+#include "ux_device_stack.h"
+
+
+/**************************************************************************/
+/*                                                                        */
+/*  FUNCTION                                               RELEASE        */
+/*                                                                        */
+/*    _ux_device_class_pima_uninitialize                  PORTABLE C      */
+/*                                                           6.x          */
+/*  AUTHOR                                                                */
+/*                                                                        */
+/*    Chaoqiong Xiao, Microsoft Corporation                               */
+/*                                                                        */
+/*  DESCRIPTION                                                           */
+/*                                                                        */
+/*    This function uninitializes the USB pima device.                    */
+/*                                                                        */
+/*  INPUT                                                                 */
+/*                                                                        */
+/*    command                              Pointer to pima command        */
+/*                                                                        */
+/*  OUTPUT                                                                */
+/*                                                                        */
+/*    Completion Status                                                   */
+/*                                                                        */
+/*  CALLS                                                                 */
+/*                                                                        */
+/*    _ux_device_thread_delete             Remove storage thread.         */
+/*    _ux_utility_memory_free              Free memory used by storage    */
+/*    _ux_utility_semaphore_delete         Remove semaphore structure     */
+/*                                                                        */
+/*                                                                        */
+/*  CALLED BY                                                             */
+/*                                                                        */
+/*    USBX Source Code                                                    */
+/*                                                                        */
+/*  RELEASE HISTORY                                                       */
+/*                                                                        */
+/*    DATE              NAME                      DESCRIPTION             */
+/*                                                                        */
+/*  xx-xx-xxxx     Chaoqiong Xiao           Initial Version 6.x           */
+/*                                                                        */
+/**************************************************************************/
+UINT  _ux_device_class_pima_uninitialize(UX_SLAVE_CLASS_COMMAND *command)
+{
+
+  UX_SLAVE_CLASS_PIMA     *pima;
+  UX_SLAVE_CLASS          *class_ptr;
+
+
+  /* Get the class container.  */
+  class_ptr =  command -> ux_slave_class_command_class_ptr;
+
+  /* Get the class instance in the container.  */
+  pima = (UX_SLAVE_CLASS_PIMA *) class_ptr -> ux_slave_class_instance;
+
+  /* Sanity check.  */
+  if (pima != UX_NULL)
+  {
+
+#if !defined(UX_DEVICE_STANDALONE)
+
+    /* Remove PIMA thread.  */
+    _ux_device_thread_delete(&class_ptr -> ux_slave_class_thread);
+
+    /* Remove the thread used by PIMA.  */
+    _ux_utility_memory_free(class_ptr -> ux_slave_class_thread_stack);
+
+    /* Remove PIMA interrupt thread.  */
+    _ux_device_thread_delete(&pima -> ux_device_class_pima_interrupt_thread);
+
+    /* Remove the interrupt semaphore used by PIMA.  */
+    _ux_device_semaphore_delete(&pima -> ux_device_class_pima_interrupt_thread_semaphore);
+
+    /* Remove the interrupt thread used by PIMA.  */
+    _ux_utility_memory_free(pima -> ux_device_class_pima_interrupt_thread_stack );
+#endif
+
+#if UX_DEVICE_ENDPOINT_BUFFER_OWNER == 1
+    _ux_utility_memory_free(pima -> ux_device_class_pima_endpoint_buffer);
+#endif
+  }
+
+  /* Free the resources.  */
+  _ux_utility_memory_free(pima);
+
+  /* Return completion status.  */
+  return(UX_SUCCESS);
+}
+

--- a/common/usbx_device_classes/src/ux_device_class_printer_entry.c
+++ b/common/usbx_device_classes/src/ux_device_class_printer_entry.c
@@ -1,10 +1,10 @@
 /***************************************************************************
- * Copyright (c) 2024 Microsoft Corporation 
- * 
+ * Copyright (c) 2024 Microsoft Corporation
+ *
  * This program and the accompanying materials are made available under the
  * terms of the MIT License which is available at
  * https://opensource.org/licenses/MIT.
- * 
+ *
  * SPDX-License-Identifier: MIT
  **************************************************************************/
 
@@ -33,7 +33,7 @@
 /*  FUNCTION                                               RELEASE        */
 /*                                                                        */
 /*    _ux_device_class_printer_entry                      PORTABLE C      */
-/*                                                           6.2.1        */
+/*                                                           6.x          */
 /*  AUTHOR                                                                */
 /*                                                                        */
 /*    Chaoqiong Xiao, Microsoft Corporation                               */
@@ -74,6 +74,9 @@
 /*  03-08-2023     Yajun Xia                Modified comment(s),          */
 /*                                            added error checks support, */
 /*                                            resulting in version 6.2.1  */
+/*  xx-xx-xxxx     Mohamed ayed             Modified comment(s),          */
+/*                                            fix typo,                   */
+/*                                            resulting in version 6.x    */
 /*                                                                        */
 /**************************************************************************/
 UINT  _ux_device_class_printer_entry(UX_SLAVE_CLASS_COMMAND *command)
@@ -101,7 +104,7 @@ UINT        status;
 
     case UX_SLAVE_CLASS_COMMAND_UNINITIALIZE:
 
-        /* Call the init function of the Printer class.  */
+        /* Call the uninit function of the Printer class.  */
         status =  _ux_device_class_printer_uninitialize(command);
 
         /* Return the completion status.  */

--- a/common/usbx_device_classes/src/ux_device_class_rndis_entry.c
+++ b/common/usbx_device_classes/src/ux_device_class_rndis_entry.c
@@ -1,17 +1,17 @@
 /***************************************************************************
- * Copyright (c) 2024 Microsoft Corporation 
- * 
+ * Copyright (c) 2024 Microsoft Corporation
+ *
  * This program and the accompanying materials are made available under the
  * terms of the MIT License which is available at
  * https://opensource.org/licenses/MIT.
- * 
+ *
  * SPDX-License-Identifier: MIT
  **************************************************************************/
 
 /**************************************************************************/
 /**************************************************************************/
-/**                                                                       */ 
-/** USBX Component                                                        */ 
+/**                                                                       */
+/** USBX Component                                                        */
 /**                                                                       */
 /**   Device RNDIS Class                                                  */
 /**                                                                       */
@@ -28,49 +28,55 @@
 #include "ux_device_stack.h"
 
 
-/**************************************************************************/ 
-/*                                                                        */ 
-/*  FUNCTION                                               RELEASE        */ 
-/*                                                                        */ 
-/*    _ux_device_class_rndis_entry                        PORTABLE C      */ 
-/*                                                           6.1          */
+/**************************************************************************/
+/*                                                                        */
+/*  FUNCTION                                               RELEASE        */
+/*                                                                        */
+/*    _ux_device_class_rndis_entry                        PORTABLE C      */
+/*                                                           6.x          */
 /*  AUTHOR                                                                */
 /*                                                                        */
 /*    Chaoqiong Xiao, Microsoft Corporation                               */
 /*                                                                        */
 /*  DESCRIPTION                                                           */
-/*                                                                        */ 
-/*    This function is the entry point of the rndis class. It             */ 
-/*    will be called by the device stack enumeration module when the      */ 
+/*                                                                        */
+/*    This function is the entry point of the rndis class. It             */
+/*    will be called by the device stack enumeration module when the      */
 /*    host has sent a SET_CONFIGURATION command and the rndis interface   */
 /*    needs to be mounted.                                                */
-/*                                                                        */ 
-/*  INPUT                                                                 */ 
-/*                                                                        */ 
-/*    command                               Pointer to class command      */ 
-/*                                                                        */ 
-/*  OUTPUT                                                                */ 
-/*                                                                        */ 
-/*    Completion Status                                                   */ 
-/*                                                                        */ 
-/*  CALLS                                                                 */ 
-/*                                                                        */ 
+/*                                                                        */
+/*  INPUT                                                                 */
+/*                                                                        */
+/*    command                               Pointer to class command      */
+/*                                                                        */
+/*  OUTPUT                                                                */
+/*                                                                        */
+/*    Completion Status                                                   */
+/*                                                                        */
+/*  CALLS                                                                 */
+/*                                                                        */
 /*    _ux_device_class_rndis_initialize       Initialize rndis class      */
-/*    _ux_device_class_rndis_activate         Activate rndis class        */ 
-/*    _ux_device_class_rndis_deactivate       Deactivate rndis class      */ 
-/*    _ux_device_class_rndis_control_request  Request control             */ 
-/*                                                                        */ 
-/*  CALLED BY                                                             */ 
-/*                                                                        */ 
+/*    _ux_device_class_rndis_uninitialize     Uninitialize rndis class    */
+/*    _ux_device_class_rndis_activate         Activate rndis class        */
+/*    _ux_device_class_rndis_deactivate       Deactivate rndis class      */
+/*    _ux_device_class_rndis_control_request  Request control             */
+/*                                                                        */
+/*  CALLED BY                                                             */
+/*                                                                        */
 /*    RNDIS Class                                                         */
-/*                                                                        */ 
-/*  RELEASE HISTORY                                                       */ 
-/*                                                                        */ 
-/*    DATE              NAME                      DESCRIPTION             */ 
-/*                                                                        */ 
+/*                                                                        */
+/*  RELEASE HISTORY                                                       */
+/*                                                                        */
+/*    DATE              NAME                      DESCRIPTION             */
+/*                                                                        */
 /*  05-19-2020     Chaoqiong Xiao           Initial Version 6.0           */
 /*  09-30-2020     Chaoqiong Xiao           Modified comment(s),          */
 /*                                            resulting in version 6.1    */
+/*  xx-xx-xxxx     Mohamed ayed             Modified comment(s),          */
+/*                                            added call of rndis uninit  */
+/*                                            function,                   */
+/*                                            remove extra spaces,        */
+/*                                            resulting in version 6.x    */
 /*                                                                        */
 /**************************************************************************/
 UINT  _ux_device_class_rndis_entry(UX_SLAVE_CLASS_COMMAND *command)
@@ -87,15 +93,22 @@ UINT        status;
 
         /* Call the init function of the RNDIS class.  */
         status =  _ux_device_class_rndis_initialize(command);
-        
+
         /* Return the completion status.  */
         return(status);
 
+    case UX_SLAVE_CLASS_COMMAND_UNINITIALIZE:
+
+        /* Call the uninit function of the RNDIS class.  */
+        status =  _ux_device_class_rndis_uninitialize(command);
+
+        /* Return the completion status.  */
+        return(status);
 
     case UX_SLAVE_CLASS_COMMAND_QUERY:
 
         /* Check the CLASS definition in the interface descriptor. */
-        if (command -> ux_slave_class_command_class == UX_DEVICE_CLASS_RNDIS_CLASS_COMMUNICATION_CONTROL || 
+        if (command -> ux_slave_class_command_class == UX_DEVICE_CLASS_RNDIS_CLASS_COMMUNICATION_CONTROL ||
                 command -> ux_slave_class_command_class == UX_DEVICE_CLASS_RNDIS_CLASS_COMMUNICATION_DATA)
             return(UX_SUCCESS);
         else
@@ -116,7 +129,7 @@ UINT        status;
         /* The deactivate command is used when the device has been extracted.
            The device endpoints have to be dismounted and the rndis thread canceled.  */
         status =  _ux_device_class_rndis_deactivate(command);
-        
+
         /* Return the completion status.  */
         return(status);
 
@@ -128,7 +141,7 @@ UINT        status;
         /* Return the completion status.  */
         return(status);
 
-    default: 
+    default:
 
         /* Error trap. */
         _ux_system_error_handler(UX_SYSTEM_LEVEL_THREAD, UX_SYSTEM_CONTEXT_CLASS, UX_FUNCTION_NOT_SUPPORTED);
@@ -138,6 +151,6 @@ UINT        status;
 
         /* Return an error.  */
         return(UX_FUNCTION_NOT_SUPPORTED);
-    }   
+    }
 }
 

--- a/common/usbx_device_classes/src/ux_device_class_rndis_uninitialize.c
+++ b/common/usbx_device_classes/src/ux_device_class_rndis_uninitialize.c
@@ -1,0 +1,131 @@
+/***************************************************************************
+ * Copyright (c) 2024 Microsoft Corporation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License which is available at
+ * https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: MIT
+ **************************************************************************/
+
+/**************************************************************************/
+/**************************************************************************/
+/**                                                                       */
+/** USBX Component                                                        */
+/**                                                                       */
+/**   Device RNDIS Class                                                  */
+/**                                                                       */
+/**************************************************************************/
+/**************************************************************************/
+
+#define UX_SOURCE_CODE
+
+
+/* Include necessary system files.  */
+
+#include "ux_api.h"
+#include "ux_device_class_rndis.h"
+#include "ux_device_stack.h"
+
+
+/**************************************************************************/
+/*                                                                        */
+/*  FUNCTION                                               RELEASE        */
+/*                                                                        */
+/*    _ux_device_class_rndis_uninitialize                 PORTABLE C      */
+/*                                                           6.xx         */
+/*  AUTHOR                                                                */
+/*                                                                        */
+/*    Chaoqiong Xiao, Microsoft Corporation                               */
+/*                                                                        */
+/*  DESCRIPTION                                                           */
+/*                                                                        */
+/*    This function deinitializes the resources for the specified RNDIS   */
+/*    instance.                                                           */
+/*                                                                        */
+/*  INPUT                                                                 */
+/*                                                                        */
+/*    command                               Pointer to rndis command      */
+/*                                                                        */
+/*  OUTPUT                                                                */
+/*                                                                        */
+/*    Completion Status                                                   */
+/*                                                                        */
+/*  CALLS                                                                 */
+/*                                                                        */
+/*    _ux_device_mutex_delete               Delete mutex                  */
+/*    _ux_device_thread_delete              Delete thread                 */
+/*    _ux_utility_memory_free               Free memory                   */
+/*    _ux_utility_event_flags_delete        Delete event flags            */
+/*    _ux_device_semaphore_delete           Delete semaphore              */
+/*                                                                        */
+/*  CALLED BY                                                             */
+/*                                                                        */
+/*    Device RNDIS Class                                                  */
+/*                                                                        */
+/*  RELEASE HISTORY                                                       */
+/*                                                                        */
+/*    DATE              NAME                      DESCRIPTION             */
+/*                                                                        */
+/*  xx-xx-xxxx     Mohamed ayed             Initial Version 6.x           */
+/*                                                                        */
+/**************************************************************************/
+UINT  _ux_device_class_rndis_uninitialize(UX_SLAVE_CLASS_COMMAND *command)
+{
+
+UX_SLAVE_CLASS_RNDIS                    *rndis;
+UX_SLAVE_CLASS                          *class_ptr;
+
+
+    /* Get the class container.  */
+    class_ptr =  command -> ux_slave_class_command_class_ptr;
+
+    /* Get the class instance in the container.  */
+    rndis = (UX_SLAVE_CLASS_RNDIS *) class_ptr -> ux_slave_class_instance;
+
+    /* Sanity check.  */
+    if (rndis != UX_NULL)
+    {
+
+        /* Deinitialize resources. We do not check if they have been allocated
+           because if they weren't, the class register (called by the application)
+           would have failed.  */
+
+#if !defined(UX_DEVICE_STANDALONE)
+
+        /* Delete the queue mutex.  */
+        _ux_device_mutex_delete(&rndis -> ux_slave_class_rndis_mutex);
+
+        /* Delete bulk out thread .  */
+        _ux_device_thread_delete(&rndis -> ux_slave_class_rndis_bulkout_thread);
+
+        /* Free bulk out thread stack.  */
+        _ux_utility_memory_free(rndis -> ux_slave_class_rndis_bulkout_thread_stack);
+
+        /* Delete interrupt thread.  */
+        _ux_device_thread_delete(&rndis -> ux_slave_class_rndis_interrupt_thread);
+
+        /* Free interrupt thread stack.  */
+        _ux_utility_memory_free(rndis -> ux_slave_class_rndis_interrupt_thread_stack);
+
+        /* Delete bulk in thread.  */
+        _ux_device_thread_delete(&rndis -> ux_slave_class_rndis_bulkin_thread);
+
+        /* Free bulk in thread stack.  */
+        _ux_utility_memory_free(rndis -> ux_slave_class_rndis_bulkin_thread_stack);
+
+        /* Delete the interrupt thread sync event flags group.  */
+        _ux_device_event_flags_delete(&rndis -> ux_slave_class_rndis_event_flags_group);
+
+#endif
+
+        /* Free the resources.  */
+#if UX_DEVICE_ENDPOINT_BUFFER_OWNER == 1
+        _ux_utility_memory_free(rndis -> ux_device_class_rndis_endpoint_buffer);
+#endif
+        _ux_utility_memory_free(rndis);
+    }
+
+    /* Return completion status.  */
+    return(UX_SUCCESS);
+}

--- a/common/usbx_device_classes/src/ux_device_class_storage_entry.c
+++ b/common/usbx_device_classes/src/ux_device_class_storage_entry.c
@@ -1,18 +1,18 @@
 /***************************************************************************
- * Copyright (c) 2024 Microsoft Corporation 
- * 
+ * Copyright (c) 2024 Microsoft Corporation
+ *
  * This program and the accompanying materials are made available under the
  * terms of the MIT License which is available at
  * https://opensource.org/licenses/MIT.
- * 
+ *
  * SPDX-License-Identifier: MIT
  **************************************************************************/
 
 
 /**************************************************************************/
 /**************************************************************************/
-/**                                                                       */ 
-/** USBX Component                                                        */ 
+/**                                                                       */
+/** USBX Component                                                        */
 /**                                                                       */
 /**   Device Storage Class                                                */
 /**                                                                       */
@@ -29,54 +29,58 @@
 #include "ux_device_stack.h"
 
 
-/**************************************************************************/ 
-/*                                                                        */ 
-/*  FUNCTION                                               RELEASE        */ 
-/*                                                                        */ 
-/*    _ux_device_class_storage_entry                      PORTABLE C      */ 
-/*                                                           6.3.0        */
+/**************************************************************************/
+/*                                                                        */
+/*  FUNCTION                                               RELEASE        */
+/*                                                                        */
+/*    _ux_device_class_storage_entry                      PORTABLE C      */
+/*                                                           6.x          */
 /*  AUTHOR                                                                */
 /*                                                                        */
 /*    Chaoqiong Xiao, Microsoft Corporation                               */
 /*                                                                        */
 /*  DESCRIPTION                                                           */
-/*                                                                        */ 
-/*    This function is the entry point of the device storage class. It    */ 
-/*    will be called by the device stack enumeration module when the      */ 
+/*                                                                        */
+/*    This function is the entry point of the device storage class. It    */
+/*    will be called by the device stack enumeration module when the      */
 /*    host has sent a SET_CONFIGURATION command and the storage interface */
 /*    needs to be mounted.                                                */
-/*                                                                        */ 
-/*  INPUT                                                                 */ 
-/*                                                                        */ 
-/*    command                               Pointer to class command      */ 
-/*                                                                        */ 
-/*  OUTPUT                                                                */ 
-/*                                                                        */ 
-/*    Completion Status                                                   */ 
-/*                                                                        */ 
-/*  CALLS                                                                 */ 
-/*                                                                        */ 
+/*                                                                        */
+/*  INPUT                                                                 */
+/*                                                                        */
+/*    command                               Pointer to class command      */
+/*                                                                        */
+/*  OUTPUT                                                                */
+/*                                                                        */
+/*    Completion Status                                                   */
+/*                                                                        */
+/*  CALLS                                                                 */
+/*                                                                        */
 /*    _ux_device_class_storage_initialize   Initialize storage class      */
 /*    _ux_device_class_storage_uninitialize Uninitialize storage class    */
-/*    _ux_device_class_storage_activate     Activate storage class        */ 
-/*    _ux_device_class_storage_deactivate   Deactivate storage class      */ 
+/*    _ux_device_class_storage_activate     Activate storage class        */
+/*    _ux_device_class_storage_deactivate   Deactivate storage class      */
 /*    _ux_device_class_storage_control_request                            */
 /*                                          Request control               */
-/*                                                                        */ 
-/*  CALLED BY                                                             */ 
-/*                                                                        */ 
+/*                                                                        */
+/*  CALLED BY                                                             */
+/*                                                                        */
 /*    Device Storage Class                                                */
-/*                                                                        */ 
-/*  RELEASE HISTORY                                                       */ 
-/*                                                                        */ 
-/*    DATE              NAME                      DESCRIPTION             */ 
-/*                                                                        */ 
+/*                                                                        */
+/*  RELEASE HISTORY                                                       */
+/*                                                                        */
+/*    DATE              NAME                      DESCRIPTION             */
+/*                                                                        */
 /*  05-19-2020     Chaoqiong Xiao           Initial Version 6.0           */
 /*  09-30-2020     Chaoqiong Xiao           Modified comment(s),          */
 /*                                            resulting in version 6.1    */
 /*  10-31-2023     Chaoqiong Xiao           Modified comment(s),          */
 /*                                            added error checks support, */
 /*                                            resulting in version 6.3.0  */
+/*  xx-xx-xxxx     Mohamed ayed             Modified comment(s),          */
+/*                                            fix typo,                   */
+/*                                            remove extra spaces,        */
+/*                                            resulting in version 6.x    */
 /*                                                                        */
 /**************************************************************************/
 UINT  _ux_device_class_storage_entry(UX_SLAVE_CLASS_COMMAND *command)
@@ -98,18 +102,18 @@ UINT        status;
 #else
         status =  _ux_device_class_storage_initialize(command);
 #endif
-        
+
         /* Return the completion status.  */
         return(status);
-        
+
     case UX_SLAVE_CLASS_COMMAND_UNINITIALIZE:
 
-        /* Call the init function of the Storage class.  */
+        /* Call the uninit function of the Storage class.  */
         status =  _ux_device_class_storage_uninitialize(command);
-        
+
         /* Return the completion status.  */
         return(status);
-        
+
 
     case UX_SLAVE_CLASS_COMMAND_QUERY:
 
@@ -134,7 +138,7 @@ UINT        status;
         /* The deactivate command is used when the device has been extracted.
            The device endpoints have to be dismounted and the storage thread canceled.  */
         status =  _ux_device_class_storage_deactivate(command);
-        
+
         /* Return the completion status.  */
         return(status);
 
@@ -146,7 +150,7 @@ UINT        status;
         /* Return the completion status.  */
         return(status);
 
-    default: 
+    default:
 
         /* Error trap. */
         _ux_system_error_handler(UX_SYSTEM_LEVEL_THREAD, UX_SYSTEM_CONTEXT_CLASS, UX_FUNCTION_NOT_SUPPORTED);
@@ -156,6 +160,6 @@ UINT        status;
 
         /* Return an error.  */
         return(UX_FUNCTION_NOT_SUPPORTED);
-    }   
+    }
 }
 

--- a/common/usbx_device_classes/src/ux_device_class_video_entry.c
+++ b/common/usbx_device_classes/src/ux_device_class_video_entry.c
@@ -1,10 +1,10 @@
 /***************************************************************************
- * Copyright (c) 2024 Microsoft Corporation 
- * 
+ * Copyright (c) 2024 Microsoft Corporation
+ *
  * This program and the accompanying materials are made available under the
  * terms of the MIT License which is available at
  * https://opensource.org/licenses/MIT.
- * 
+ *
  * SPDX-License-Identifier: MIT
  **************************************************************************/
 
@@ -33,7 +33,7 @@
 /*  FUNCTION                                               RELEASE        */
 /*                                                                        */
 /*    _ux_device_class_video_entry                        PORTABLE C      */
-/*                                                           6.3.0        */
+/*                                                           6.x          */
 /*  AUTHOR                                                                */
 /*                                                                        */
 /*    Chaoqiong Xiao, Microsoft Corporation                               */
@@ -74,6 +74,9 @@
 /*  10-31-2023     Yajun xia                Modified comment(s),          */
 /*                                            added error checks support, */
 /*                                            resulting in version 6.3.0  */
+/*  xx-xx-xxxx     Mohamed ayed             Modified comment(s),          */
+/*                                            fix typo,                   */
+/*                                            resulting in version 6.x    */
 /*                                                                        */
 /**************************************************************************/
 UINT  _ux_device_class_video_entry(UX_SLAVE_CLASS_COMMAND *command)
@@ -94,7 +97,7 @@ UINT        status;
         status =  _uxe_device_class_video_initialize(command);
 #else
 
-        /* Call the init function of the Video class.  */
+        /* Call the uninit function of the Video class.  */
         status =  _ux_device_class_video_initialize(command);
 #endif  /* UX_DEVICE_CLASS_VIDEO_ENABLE_ERROR_CHECKING */
 


### PR DESCRIPTION
- add missing free allocated memory for device classes (pima/dfu/rndis).
- remove extra spaces.
-  add hid instance sanity check in ux_device_class_hid_uninitialize before freed hid instance memory.