### PR TITLE
fix ux system enable error checking flag

### DIFF
--- a/common/core/inc/ux_api.h
+++ b/common/core/inc/ux_api.h
@@ -2740,9 +2740,9 @@ typedef struct UX_HOST_CLASS_DPUMP_STRUCT
 /* Define USBX Services.  */
 
 #if defined(UX_SYSTEM_ENABLE_ERROR_CHECKING)
-#define ux_system_initialize                                    _ux_system_initialize
-#else
 #define ux_system_initialize                                    _uxe_system_initialize
+#else
+#define ux_system_initialize                                    _ux_system_initialize
 #endif
 
 #define ux_system_uninitialize                                  _ux_system_uninitialize


### PR DESCRIPTION
It seems that ux_system_initialize is set to point to the incorrect function if UX_SYSTEM_ENABLE_ERROR_CHECKING is defined or not