### PR TITLE
fix github usbx regression test action issue 

### DIFF
--- a/.github/workflows/regression_test.yml
+++ b/.github/workflows/regression_test.yml
@@ -34,7 +34,7 @@ jobs:
       pages: write
       id-token: write
 
-    uses: azure-rtos/threadx/.github/workflows/regression_template.yml@master
+    uses: eclipse-threadx/threadx/.github/workflows/regression_template.yml@master
     with:
       cmake_path: ./test/cmake/usbx
       build_script: ./scripts/build.sh ${{ inputs.tests_to_run }}
@@ -52,7 +52,7 @@ jobs:
       pages: write
       id-token: write
 
-    uses: azure-rtos/threadx/.github/workflows/regression_template.yml@master
+    uses: eclipse-threadx/threadx/.github/workflows/regression_template.yml@master
     with:
       cmake_path: ./test/cmake/usbx
       build_script: ./scripts/build.sh all


### PR DESCRIPTION
fix github usbx regression test action issue 

- update regression_test.yml

uses: azure-rtos/threadx/.github/workflows/regression_template.yml@master
==>
uses: eclipse-threadx/threadx/.github/workflows/regression_template.yml@master