### PR TITLE
add device state check define to avoid use of internal struct fileds in app level

### DIFF
--- a/common/core/inc/ux_api.h
+++ b/common/core/inc/ux_api.h
@@ -2685,6 +2685,10 @@ typedef struct UX_SYSTEM_SLAVE_STRUCT
 #define UX_SYSTEM_DEVICE_MAX_CLASS_GET()        (1)
 #endif
 
+#define UX_SLAVE_DEVICE_CHECK_STATE(state)                                                        \
+  (_ux_system_slave->ux_system_slave_device.ux_slave_device_state & (state)) ? UX_TRUE : UX_FALSE \
+
+
 typedef struct UX_SYSTEM_OTG_STRUCT
 {
 


### PR DESCRIPTION
add a define 
```C
#define UX_SLAVE_DEVICE_CHECK_STATE(state)                                                        \
  (_ux_system_slave->ux_system_slave_device.ux_slave_device_state & (state)) ? UX_TRUE : UX_FALSE \
```

instead of testing device state at applicative level  
```C
     UX_SLAVE_DEVICE *device;
     device = &_ux_system_slave->ux_system_slave_device;

    /* Check if the device state already configured */
    if ((device->ux_slave_device_state == UX_DEVICE_CONFIGURED) && (hid_mouse != UX_NULL))
    {
    }
```

we can do that :
```C
      if ((UX_SLAVE_DEVICE_CHECK_STATE(UX_DEVICE_CONFIGURED)) && (hid_mouse != UX_NULL))
      {
      }
```