### PR TITLE
DCD Simulator Controller Driver: Add uninitialize API

### DIFF
--- a/common/core/CMakeLists.txt
+++ b/common/core/CMakeLists.txt
@@ -10,6 +10,7 @@ target_sources(${PROJECT_NAME} PRIVATE
 	${CMAKE_CURRENT_LIST_DIR}/src/ux_dcd_sim_slave_function.c
 	${CMAKE_CURRENT_LIST_DIR}/src/ux_dcd_sim_slave_initialize.c
 	${CMAKE_CURRENT_LIST_DIR}/src/ux_dcd_sim_slave_initialize_complete.c
+	${CMAKE_CURRENT_LIST_DIR}/src/ux_dcd_sim_slave_uninitialize.c
 	${CMAKE_CURRENT_LIST_DIR}/src/ux_dcd_sim_slave_state_change.c
 	${CMAKE_CURRENT_LIST_DIR}/src/ux_dcd_sim_slave_transfer_abort.c
 	${CMAKE_CURRENT_LIST_DIR}/src/ux_dcd_sim_slave_transfer_request.c

--- a/common/core/inc/ux_dcd_sim_slave.h
+++ b/common/core/inc/ux_dcd_sim_slave.h
@@ -1,18 +1,18 @@
 /***************************************************************************
- * Copyright (c) 2024 Microsoft Corporation 
- * 
+ * Copyright (c) 2024 Microsoft Corporation
+ *
  * This program and the accompanying materials are made available under the
  * terms of the MIT License which is available at
  * https://opensource.org/licenses/MIT.
- * 
+ *
  * SPDX-License-Identifier: MIT
  **************************************************************************/
 
 
 /**************************************************************************/
 /**************************************************************************/
-/**                                                                       */ 
-/** USBX Component                                                        */ 
+/**                                                                       */
+/** USBX Component                                                        */
 /**                                                                       */
 /**   Slave Simulator Controller Driver                                   */
 /**                                                                       */
@@ -20,26 +20,26 @@
 /**************************************************************************/
 
 
-/**************************************************************************/ 
-/*                                                                        */ 
-/*  COMPONENT DEFINITION                                   RELEASE        */ 
-/*                                                                        */ 
-/*    ux_dcd_sim_slave.h                                  PORTABLE C      */ 
+/**************************************************************************/
+/*                                                                        */
+/*  COMPONENT DEFINITION                                   RELEASE        */
+/*                                                                        */
+/*    ux_dcd_sim_slave.h                                  PORTABLE C      */
 /*                                                           6.1.10       */
 /*  AUTHOR                                                                */
 /*                                                                        */
 /*    Chaoqiong Xiao, Microsoft Corporation                               */
 /*                                                                        */
 /*  DESCRIPTION                                                           */
-/*                                                                        */ 
+/*                                                                        */
 /*    This file contains all the header and extern functions used by the  */
-/*    USBX slave simulator. It is designed to work ONLY with the USBX     */ 
-/*    host simulator.                                                     */ 
-/*                                                                        */ 
-/*  RELEASE HISTORY                                                       */ 
-/*                                                                        */ 
-/*    DATE              NAME                      DESCRIPTION             */ 
-/*                                                                        */ 
+/*    USBX slave simulator. It is designed to work ONLY with the USBX     */
+/*    host simulator.                                                     */
+/*                                                                        */
+/*  RELEASE HISTORY                                                       */
+/*                                                                        */
+/*    DATE              NAME                      DESCRIPTION             */
+/*                                                                        */
 /*  05-19-2020     Chaoqiong Xiao           Initial Version 6.0           */
 /*  09-30-2020     Chaoqiong Xiao           Modified comment(s),          */
 /*                                            resulting in version 6.1    */
@@ -60,15 +60,15 @@
 #ifndef UX_DCD_SIM_SLAVE_H
 #define UX_DCD_SIM_SLAVE_H
 
-/* Determine if a C++ compiler is being used.  If so, ensure that standard 
-   C is used to process the API information.  */ 
+/* Determine if a C++ compiler is being used.  If so, ensure that standard
+   C is used to process the API information.  */
 
-#ifdef   __cplusplus 
+#ifdef   __cplusplus
 
-/* Yes, C++ compiler is present.  Use standard C.  */ 
-extern   "C" { 
+/* Yes, C++ compiler is present.  Use standard C.  */
+extern   "C" {
 
-#endif  
+#endif
 
 
 /* Define USB slave simulator major equivalences.  */
@@ -110,7 +110,7 @@ extern   "C" {
 
 /* Define USB slave simulator physical endpoint structure.  */
 
-typedef struct UX_DCD_SIM_SLAVE_ED_STRUCT 
+typedef struct UX_DCD_SIM_SLAVE_ED_STRUCT
 {
 
     ULONG           ux_sim_slave_ed_status;
@@ -119,7 +119,7 @@ typedef struct UX_DCD_SIM_SLAVE_ED_STRUCT
     ULONG           ux_sim_slave_ed_ping_pong;
     ULONG           ux_sim_slave_ed_status_register;
     ULONG           ux_sim_slave_ed_configuration_value;
-    struct UX_SLAVE_ENDPOINT_STRUCT             
+    struct UX_SLAVE_ENDPOINT_STRUCT
                     *ux_sim_slave_ed_endpoint;
 } UX_DCD_SIM_SLAVE_ED;
 
@@ -127,14 +127,14 @@ typedef struct UX_DCD_SIM_SLAVE_ED_STRUCT
 /* Define USB slave simulator DCD structure definition.  */
 
 typedef struct UX_DCD_SIM_SLAVE_STRUCT
-{                                 
+{
 
-    struct UX_SLAVE_DCD_STRUCT                 
+    struct UX_SLAVE_DCD_STRUCT
                     *ux_dcd_sim_slave_dcd_owner;
-    struct UX_DCD_SIM_SLAVE_ED_STRUCT              
+    struct UX_DCD_SIM_SLAVE_ED_STRUCT
                     ux_dcd_sim_slave_ed[UX_DCD_SIM_SLAVE_MAX_ED];
 #ifdef UX_DEVICE_BIDIRECTIONAL_ENDPOINT_SUPPORT
-    struct UX_DCD_SIM_SLAVE_ED_STRUCT              
+    struct UX_DCD_SIM_SLAVE_ED_STRUCT
                     ux_dcd_sim_slave_ed_in[UX_DCD_SIM_SLAVE_MAX_ED];
 #endif
     UINT            (*ux_dcd_sim_slave_dcd_control_request_process_hub)(UX_SLAVE_TRANSFER *transfer_request);
@@ -154,6 +154,7 @@ UINT    _ux_dcd_sim_slave_frame_number_get(UX_DCD_SIM_SLAVE *dcd_sim_slave, ULON
 UINT    _ux_dcd_sim_slave_function(UX_SLAVE_DCD *dcd, UINT function, VOID *parameter);
 UINT    _ux_dcd_sim_slave_initialize(VOID);
 UINT    _ux_dcd_sim_slave_initialize_complete(VOID);
+UINT    _ux_dcd_sim_slave_uninitialize(VOID);
 UINT    _ux_dcd_sim_slave_state_change(UX_DCD_SIM_SLAVE *dcd_sim_slave, ULONG state);
 UINT    _ux_dcd_sim_slave_transfer_request(UX_DCD_SIM_SLAVE *dcd_sim_slave, UX_SLAVE_TRANSFER *transfer_request);
 UINT    _ux_dcd_sim_slave_transfer_run(UX_DCD_SIM_SLAVE *dcd_sim_slave, UX_SLAVE_TRANSFER *transfer_request);
@@ -162,11 +163,12 @@ UINT    _ux_dcd_sim_slave_transfer_abort(UX_DCD_SIM_SLAVE *dcd_sim_slave, UX_SLA
 /* Define Device Simulator Class API prototypes.  */
 
 #define ux_dcd_sim_slave_initialize                 _ux_dcd_sim_slave_initialize
+#define ux_dcd_sim_slave_uninitialize               _ux_dcd_sim_slave_uninitialize
 
-/* Determine if a C++ compiler is being used.  If so, complete the standard 
-   C conditional started above.  */   
+/* Determine if a C++ compiler is being used.  If so, complete the standard
+   C conditional started above.  */
 #ifdef __cplusplus
-} 
+}
 #endif
 
 #endif

--- a/common/core/src/ux_dcd_sim_slave_uninitialize.c
+++ b/common/core/src/ux_dcd_sim_slave_uninitialize.c
@@ -1,0 +1,88 @@
+/***************************************************************************
+ * Copyright (c) 2025-present Eclipse ThreadX Contributors
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License which is available at
+ * https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: MIT
+ **************************************************************************/
+
+
+/**************************************************************************/
+/**************************************************************************/
+/**                                                                       */
+/** USBX Component                                                        */
+/**                                                                       */
+/**   Slave Simulator Controller Driver                                   */
+/**                                                                       */
+/**************************************************************************/
+/**************************************************************************/
+
+#define UX_SOURCE_CODE
+
+
+/* Include necessary system files.  */
+
+#include "ux_api.h"
+#include "ux_dcd_sim_slave.h"
+
+
+/**************************************************************************/
+/*                                                                        */
+/*  FUNCTION                                               RELEASE        */
+/*                                                                        */
+/*    _ux_dcd_sim_slave_uninitialize                      PORTABLE C      */
+/*                                                                        */
+/*  DESCRIPTION                                                           */
+/*                                                                        */
+/*    This function uninitializes the USB simulation slave controller.    */
+/*    The controller releases its resources (memory ...).                 */
+/*                                                                        */
+/*  INPUT                                                                 */
+/*                                                                        */
+/*    None                                                                */
+/*                                                                        */
+/*  OUTPUT                                                                */
+/*                                                                        */
+/*    Completion Status                                                   */
+/*                                                                        */
+/*  CALLS                                                                 */
+/*                                                                        */
+/*    _ux_utility_memory_free               Free memory block             */
+/*                                                                        */
+/*  CALLED BY                                                             */
+/*                                                                        */
+/*    Application                                                         */
+/*                                                                        */
+/**************************************************************************/
+UINT  _ux_dcd_sim_slave_uninitialize(VOID)
+{
+
+UX_SLAVE_DCD            *dcd;
+UX_DCD_SIM_SLAVE        *dcd_sim_slave;
+
+    /* Get the pointer to the DCD.  */
+    dcd = &_ux_system_slave -> ux_system_slave_dcd;
+
+    /* If already unused, treat as success.  */
+    if (dcd -> ux_slave_dcd_status == UX_UNUSED)
+        return(UX_SUCCESS);
+
+    /* Set the state of the controller to HALTED first.  */
+    dcd -> ux_slave_dcd_status = UX_DCD_STATUS_HALTED;
+
+    /* Free the simulated slave controller.  */
+    dcd_sim_slave = (UX_DCD_SIM_SLAVE *) dcd -> ux_slave_dcd_controller_hardware;
+    if (dcd_sim_slave != UX_NULL)
+        _ux_utility_memory_free(dcd_sim_slave);
+
+    /* Clear DCD bindings.  */
+    dcd -> ux_slave_dcd_controller_hardware = UX_NULL;
+    dcd -> ux_slave_dcd_function = UX_NULL;
+
+    /* Set the state of the controller to UNUSED.  */
+    dcd -> ux_slave_dcd_status = UX_UNUSED;
+
+    return(UX_SUCCESS);
+}


### PR DESCRIPTION
- Adds _ux_dcd_sim_slave_uninitialize() to free the simulated slave DCD controller instance, clear DCD bindings, and return the DCD to UX_UNUSED (idempotent if already unused).
- Registers the new uninitialize source in CMakeLists.txt.
- Updates simulator headers to export ux_dcd_sim_slave_uninitialize and does minor whitespace/style cleanup in the simulator header blocks.