### PR TITLE
remove duplicated defines

### DIFF
--- a/ports/cortex_r4/gnu/inc/ux_port.h
+++ b/ports/cortex_r4/gnu/inc/ux_port.h
@@ -217,9 +217,6 @@ typedef LONG                        SLONG;
 #define UX_SLAVE_REQUEST_DATA_MAX_LENGTH                    4096
 #endif
 
-#ifndef UX_HOST_CLASS_STORAGE_MAX_PARTITIONS_COUNT
-#define UX_HOST_CLASS_STORAGE_MAX_PARTITIONS_COUNT          8
-#endif
 
 #ifndef UX_USE_IO_INSTRUCTIONS
 

--- a/ports/cortex_r4/iar/inc/ux_port.h
+++ b/ports/cortex_r4/iar/inc/ux_port.h
@@ -217,10 +217,6 @@ typedef LONG                        SLONG;
 #define UX_SLAVE_REQUEST_DATA_MAX_LENGTH                    4096
 #endif
 
-#ifndef UX_HOST_CLASS_STORAGE_MAX_PARTITIONS_COUNT
-#define UX_HOST_CLASS_STORAGE_MAX_PARTITIONS_COUNT          8
-#endif
-
 #ifndef UX_USE_IO_INSTRUCTIONS
 
 /* Don't use IO instructions if this define is not set.  Default to memory mapped.  */

--- a/ports/cortex_r5/gnu/inc/ux_port.h
+++ b/ports/cortex_r5/gnu/inc/ux_port.h
@@ -217,10 +217,6 @@ typedef LONG                        SLONG;
 #define UX_SLAVE_REQUEST_DATA_MAX_LENGTH                    4096
 #endif
 
-#ifndef UX_HOST_CLASS_STORAGE_MAX_PARTITIONS_COUNT
-#define UX_HOST_CLASS_STORAGE_MAX_PARTITIONS_COUNT          8
-#endif
-
 #ifndef UX_USE_IO_INSTRUCTIONS
 
 /* Don't use IO instructions if this define is not set.  Default to memory mapped.  */

--- a/ports/cortex_r5/iar/inc/ux_port.h
+++ b/ports/cortex_r5/iar/inc/ux_port.h
@@ -217,10 +217,6 @@ typedef LONG                        SLONG;
 #define UX_SLAVE_REQUEST_DATA_MAX_LENGTH                    4096
 #endif
 
-#ifndef UX_HOST_CLASS_STORAGE_MAX_PARTITIONS_COUNT
-#define UX_HOST_CLASS_STORAGE_MAX_PARTITIONS_COUNT          8
-#endif
-
 #ifndef UX_USE_IO_INSTRUCTIONS
 
 /* Don't use IO instructions if this define is not set.  Default to memory mapped.  */

--- a/ports/linux/gnu/inc/ux_port.h
+++ b/ports/linux/gnu/inc/ux_port.h
@@ -223,10 +223,6 @@ typedef LONG                        SLONG;
 #define UX_SLAVE_REQUEST_DATA_MAX_LENGTH                    4096
 #endif
 
-#ifndef UX_HOST_CLASS_STORAGE_MAX_PARTITIONS_COUNT
-#define UX_HOST_CLASS_STORAGE_MAX_PARTITIONS_COUNT          8
-#endif
-
 #ifndef UX_USE_IO_INSTRUCTIONS
 
 /* Don't use IO instructions if this define is not set.  Default to memory mapped.  */


### PR DESCRIPTION
Remove duplicated defines 

#ifndef UX_HOST_CLASS_STORAGE_MAX_PARTITIONS_COUNT
#define UX_HOST_CLASS_STORAGE_MAX_PARTITIONS_COUNT          8
#endif

in:
- ports\cortex_r4\gnu\inc\ux_port.h
- ports\cortex_r4\iar\inc\ux_port.h
- ports\cortex_r5\gnu\inc\ux_port.h
- ports\cortex_r5\iar\inc\ux_port.h
- ports\linux\gnu\inc\ux_port.h