### PR TITLE
create mutex before calling _ux_utility_memory_allocate

### DIFF
--- a/common/core/src/ux_system_initialize.c
+++ b/common/core/src/ux_system_initialize.c
@@ -261,6 +261,14 @@ ULONG               pool_size;
     /* Other fields are kept zero.  */
 #endif
 
+#if !defined(UX_STANDALONE)
+
+    /* Create the Mutex object used by USBX to control critical sections.  */
+    status =  _ux_system_mutex_create(&_ux_system -> ux_system_mutex, "ux_system_mutex");
+    if(status != UX_SUCCESS)
+        return(UX_MUTEX_ERROR);
+#endif
+
 #ifdef UX_ENABLE_DEBUG_LOG
 
     /* Obtain memory for storing the debug log.  */
@@ -275,14 +283,6 @@ ULONG               pool_size;
     /* Keep the size in system structure variable.  */
     _ux_system -> ux_system_debug_log_size = UX_DEBUG_LOG_SIZE;
 
-#endif
-
-#if !defined(UX_STANDALONE)
-
-    /* Create the Mutex object used by USBX to control critical sections.  */
-    status =  _ux_system_mutex_create(&_ux_system -> ux_system_mutex, "ux_system_mutex");
-    if(status != UX_SUCCESS)
-        return(UX_MUTEX_ERROR);
 #endif
 
     return(UX_SUCCESS);


### PR DESCRIPTION
When compiling with UX_ENABLE_DEBUG_LOG the call to _ux_utility_memory_allocate requires the system mutex.
So the mutex needs to be created before allocating memory for the debug log.