### PR TITLE
Pre v6.5.0.202601 fixes

### DIFF
--- a/common/usbx_host_classes/inc/ux_host_class_hid.h
+++ b/common/usbx_host_classes/inc/ux_host_class_hid.h
@@ -1069,7 +1069,7 @@ UINT    _ux_host_class_hid_report_decompress(UX_HOST_CLASS_HID *hid, UX_HOST_CLA
 UINT    _ux_host_class_hid_report_descriptor_get(UX_HOST_CLASS_HID *hid, ULONG length);
 UINT    _ux_host_class_hid_report_get(UX_HOST_CLASS_HID *hid, UX_HOST_CLASS_HID_CLIENT_REPORT *client_report);
 UINT    _ux_host_class_hid_report_id_get(UX_HOST_CLASS_HID *hid, UX_HOST_CLASS_HID_REPORT_GET_ID *report_id);
-UINT    _ux_host_class_hid_report_item_analyse(UCHAR *descriptor, UX_HOST_CLASS_HID_ITEM *item);
+UINT    _ux_host_class_hid_report_item_analyse(UCHAR *descriptor, ULONG length, UX_HOST_CLASS_HID_ITEM *item);
 UINT    _ux_host_class_hid_report_set(UX_HOST_CLASS_HID *hid, UX_HOST_CLASS_HID_CLIENT_REPORT *client_report);
 UINT    _ux_host_class_hid_resources_free(UX_HOST_CLASS_HID *hid);
 VOID    _ux_host_class_hid_transfer_request_completed(UX_TRANSFER *transfer_request);

--- a/common/usbx_host_classes/src/ux_host_class_hid_entry.c
+++ b/common/usbx_host_classes/src/ux_host_class_hid_entry.c
@@ -358,7 +358,7 @@ UINT                    status = UX_SUCCESS;
     {
 
         /* Get one item from the report and analyze it.  */
-        _ux_host_class_hid_report_item_analyse(descriptor, &item);
+        _ux_host_class_hid_report_item_analyse(descriptor, length, &item);
 
         /* Point the descriptor right after the item identifier.  */
         descriptor +=  item.ux_host_class_hid_item_report_format;

--- a/common/usbx_host_classes/src/ux_host_class_hid_report_descriptor_get.c
+++ b/common/usbx_host_classes/src/ux_host_class_hid_report_descriptor_get.c
@@ -111,7 +111,7 @@ UINT                    status;
         {
             /* Get one item from the report and analyze it.  */
             /* Make sure this descriptor has at least the minimum length.  */
-            analysis_failure = _ux_host_class_hid_report_item_analyse(descriptor, &item);
+            analysis_failure = _ux_host_class_hid_report_item_analyse(descriptor, length, &item);
             if (analysis_failure)
             {
               /* Error trap. */

--- a/common/usbx_host_classes/src/ux_host_class_hid_report_item_analyse.c
+++ b/common/usbx_host_classes/src/ux_host_class_hid_report_item_analyse.c
@@ -47,6 +47,7 @@
 /*  INPUT                                                                 */
 /*                                                                        */
 /*    descriptor                            Pointer to descriptor         */
+/*    length                                Length of descriptor          */
 /*    item                                  Pointer to item               */
 /*                                                                        */
 /*  OUTPUT                                                                */
@@ -62,11 +63,17 @@
 /*    HID Class                                                           */
 /*                                                                        */
 /**************************************************************************/
-UINT  _ux_host_class_hid_report_item_analyse(UCHAR *descriptor, UX_HOST_CLASS_HID_ITEM *item)
+UINT  _ux_host_class_hid_report_item_analyse(UCHAR *descriptor, ULONG length, UX_HOST_CLASS_HID_ITEM *item)
 {
 
 UCHAR       item_byte;
 UINT        result = UX_SUCCESS;
+
+    /* Make sure descriptor has minimal length.*/
+    if (length == 0)
+    {
+        return(UX_DESCRIPTOR_CORRUPTED);
+    }
 
     /* Get the first byte from the descriptor.  */
     item_byte =  *descriptor;
@@ -83,7 +90,7 @@ UINT        result = UX_SUCCESS;
         item -> ux_host_class_hid_item_report_type =  (item_byte >> 2) & 3;
 
         /* Make sure descriptor has minimal length.*/
-        if (sizeof(descriptor) >= 3)
+        if (length >= 3)
         {
             /* Get its length (byte 1).  */
             item -> ux_host_class_hid_item_report_length =  (USHORT) *(descriptor + 1);
@@ -120,11 +127,14 @@ UINT        result = UX_SUCCESS;
         /* Set the type.  */
         item -> ux_host_class_hid_item_report_type =  (item_byte >> 2) & 3;
 
-        /* Set the tag.  */
-        item -> ux_host_class_hid_item_report_tag =  item_byte >> 4;
+        /* Then the tag.  */
+        item -> ux_host_class_hid_item_report_tag =  (item_byte >> 4) & 0xf;
+
+        /* Mark its format. For short items, this is always 1. */
+        item -> ux_host_class_hid_item_report_format = 1;
+
     }
 
-    /* Return successful completion.  */
+    /* Return result.  */
     return(result);
 }
-

--- a/ports/arm9/gnu/inc/ux_port.h
+++ b/ports/arm9/gnu/inc/ux_port.h
@@ -244,8 +244,7 @@ VOID    outpl(ULONG,ULONG);
 
 #ifdef  UX_SYSTEM_INIT
 CHAR                            _ux_version_id[] =
-                                    "Copyright (c) 2024 Microsoft Corporation. * USBX ARM9/GNU Version 6.4.1 *";
- * Copyright (c) 2026-present Eclipse ThreadX contributors
+                                    "(c) 2024 Microsoft Corp. (c) 2026-present Eclipse ThreadX contributors. * USBX ARM9/GNU Version 6.5.0.202601 *";
 #else
 extern  CHAR                    _ux_version_id[];
 #endif

--- a/ports/arm9/iar/inc/ux_port.h
+++ b/ports/arm9/iar/inc/ux_port.h
@@ -251,8 +251,7 @@ VOID    outpl(ULONG,ULONG);
 
 #ifdef  UX_SYSTEM_INIT
 CHAR                            _ux_version_id[] =
-                                    "Copyright (c) 2024 Microsoft Corporation. * USBX ARM9/IAR Version 6.4.1 *";
- * Copyright (c) 2026-present Eclipse ThreadX contributors
+                                    "(c) 2024 Microsoft Corp. (c) 2026-present Eclipse ThreadX contributors. * USBX ARM9/IAR Version 6.5.0.202601 *";
 #else
 extern  CHAR                    _ux_version_id[];
 #endif

--- a/ports/cortex_a15/gnu/inc/ux_port.h
+++ b/ports/cortex_a15/gnu/inc/ux_port.h
@@ -240,8 +240,7 @@ VOID    outpl(ULONG,ULONG);
 
 #ifdef  UX_SYSTEM_INIT
 CHAR                            _ux_version_id[] =
-                                    "Copyright (c) 2024 Microsoft Corporation. * USBX Cortex-A15/GNU Version 6.4.1 *";
- * Copyright (c) 2026-present Eclipse ThreadX contributors
+                                    "(c) 2024 Microsoft Corp. (c) 2026-present Eclipse ThreadX contributors. * USBX Cortex-A15/GNU Version 6.5.0.202601 *";
 #else
 extern  CHAR                    _ux_version_id[];
 #endif

--- a/ports/cortex_a5/gnu/inc/ux_port.h
+++ b/ports/cortex_a5/gnu/inc/ux_port.h
@@ -247,8 +247,7 @@ VOID    outpl(ULONG,ULONG);
 
 #ifdef  UX_SYSTEM_INIT
 CHAR                            _ux_version_id[] =
-                                    "Copyright (c) 2024 Microsoft Corporation. * USBX Cortex-A5/GNU Version 6.4.1 *";
- * Copyright (c) 2026-present Eclipse ThreadX contributors
+                                    "(c) 2024 Microsoft Corp. (c) 2026-present Eclipse ThreadX contributors. * USBX Cortex-A5/GNU Version 6.5.0.202601 *";
 #else
 extern  CHAR                    _ux_version_id[];
 #endif

--- a/ports/cortex_a5/iar/inc/ux_port.h
+++ b/ports/cortex_a5/iar/inc/ux_port.h
@@ -247,8 +247,7 @@ VOID    outpl(ULONG,ULONG);
 
 #ifdef  UX_SYSTEM_INIT
 CHAR                            _ux_version_id[] =
-                                    "Copyright (c) 2024 Microsoft Corporation. * USBX Cortex-A5/IAR Version 6.4.1 *";
- * Copyright (c) 2026-present Eclipse ThreadX contributors
+                                    "(c) 2024 Microsoft Corp. (c) 2026-present Eclipse ThreadX contributors. * USBX Cortex-A5/IAR Version 6.5.0.202601 *";
 #else
 extern  CHAR                    _ux_version_id[];
 #endif

--- a/ports/cortex_a5x/ac6/inc/ux_port.h
+++ b/ports/cortex_a5x/ac6/inc/ux_port.h
@@ -264,8 +264,7 @@ VOID    outpl(ULONG,ULONG);
 
 #ifdef  UX_SYSTEM_INIT
 CHAR                            _ux_version_id[] =
-                                    "Copyright (c) 2024 Microsoft Corporation. * USBX Cortex-A5x/AC6 Version 6.4.1 *";
- * Copyright (c) 2026-present Eclipse ThreadX contributors
+                                    "(c) 2024 Microsoft Corp. (c) 2026-present Eclipse ThreadX contributors. * USBX Cortex-A5x/AC6 Version 6.5.0.202601 *";
 #else
 extern  CHAR                    _ux_version_id[];
 #endif

--- a/ports/cortex_a7/gnu/inc/ux_port.h
+++ b/ports/cortex_a7/gnu/inc/ux_port.h
@@ -251,8 +251,7 @@ VOID    outpl(ULONG,ULONG);
 
 #ifdef  UX_SYSTEM_INIT
 CHAR                            _ux_version_id[] =
-                                    "Copyright (c) 2024 Microsoft Corporation. * USBX Cortex-A7/GNU Version 6.4.1 *";
- * Copyright (c) 2026-present Eclipse ThreadX contributors
+                                    "(c) 2024 Microsoft Corp. (c) 2026-present Eclipse ThreadX contributors. * USBX Cortex-A7/GNU Version 6.5.0.202601 *";
 #else
 extern  CHAR                    _ux_version_id[];
 #endif

--- a/ports/cortex_a7/iar/inc/ux_port.h
+++ b/ports/cortex_a7/iar/inc/ux_port.h
@@ -251,8 +251,7 @@ VOID    outpl(ULONG,ULONG);
 
 #ifdef  UX_SYSTEM_INIT
 CHAR                            _ux_version_id[] =
-                                    "Copyright (c) 2024 Microsoft Corporation. * USBX Cortex-A7/IAR Version 6.4.1 *";
- * Copyright (c) 2026-present Eclipse ThreadX contributors
+                                    "(c) 2024 Microsoft Corp. (c) 2026-present Eclipse ThreadX contributors. * USBX Cortex-A7/IAR Version 6.5.0.202601 *";
 #else
 extern  CHAR                    _ux_version_id[];
 #endif

--- a/ports/cortex_a8/gnu/inc/ux_port.h
+++ b/ports/cortex_a8/gnu/inc/ux_port.h
@@ -247,8 +247,7 @@ VOID    outpl(ULONG,ULONG);
 
 #ifdef  UX_SYSTEM_INIT
 CHAR                            _ux_version_id[] =
-                                    "Copyright (c) 2024 Microsoft Corporation. * USBX Cortex-A8/GNU Version 6.4.1 *";
- * Copyright (c) 2026-present Eclipse ThreadX contributors
+                                    "(c) 2024 Microsoft Corp. (c) 2026-present Eclipse ThreadX contributors. * USBX Cortex-A8/GNU Version 6.5.0.202601 *";
 #else
 extern  CHAR                    _ux_version_id[];
 #endif

--- a/ports/cortex_a8/iar/inc/ux_port.h
+++ b/ports/cortex_a8/iar/inc/ux_port.h
@@ -247,8 +247,7 @@ VOID    outpl(ULONG,ULONG);
 
 #ifdef  UX_SYSTEM_INIT
 CHAR                            _ux_version_id[] =
-                                    "Copyright (c) 2024 Microsoft Corporation. * USBX Cortex-A8/IAR Version 6.4.1 *";
- * Copyright (c) 2026-present Eclipse ThreadX contributors
+                                    "(c) 2024 Microsoft Corp. (c) 2026-present Eclipse ThreadX contributors. * USBX Cortex-A8/IAR Version 6.5.0.202601 *";
 #else
 extern  CHAR                    _ux_version_id[];
 #endif

--- a/ports/cortex_a9/gnu/inc/ux_port.h
+++ b/ports/cortex_a9/gnu/inc/ux_port.h
@@ -247,8 +247,7 @@ VOID    outpl(ULONG,ULONG);
 
 #ifdef  UX_SYSTEM_INIT
 CHAR                            _ux_version_id[] =
-                                    "Copyright (c) 2024 Microsoft Corporation. * USBX ARM9/GNU Version 6.4.1 *";
- * Copyright (c) 2026-present Eclipse ThreadX contributors
+                                    "(c) 2024 Microsoft Corp. (c) 2026-present Eclipse ThreadX contributors. * USBX ARM9/GNU Version 6.5.0.202601 *";
 #else
 extern  CHAR                    _ux_version_id[];
 #endif

--- a/ports/cortex_a9/iar/inc/ux_port.h
+++ b/ports/cortex_a9/iar/inc/ux_port.h
@@ -247,8 +247,7 @@ VOID    outpl(ULONG,ULONG);
 
 #ifdef  UX_SYSTEM_INIT
 CHAR                            _ux_version_id[] =
-                                    "Copyright (c) 2024 Microsoft Corporation. * USBX ARM9/IAR Version 6.4.1 *";
- * Copyright (c) 2026-present Eclipse ThreadX contributors
+                                    "(c) 2024 Microsoft Corp. (c) 2026-present Eclipse ThreadX contributors. * USBX ARM9/IAR Version 6.5.0.202601 *";
 #else
 extern  CHAR                    _ux_version_id[];
 #endif

--- a/ports/cortex_m0/gnu/inc/ux_port.h
+++ b/ports/cortex_m0/gnu/inc/ux_port.h
@@ -243,8 +243,7 @@ VOID    outpl(ULONG,ULONG);
 
 #ifdef  UX_SYSTEM_INIT
 CHAR                            _ux_version_id[] =
-                                    "Copyright (c) 2024 Microsoft Corporation. * USBX Cortex-M0/GNU Version 6.4.1 *";
- * Copyright (c) 2026-present Eclipse ThreadX contributors
+                                    "(c) 2024 Microsoft Corp. (c) 2026-present Eclipse ThreadX contributors. * USBX Cortex-M0/GNU Version 6.5.0.202601 *";
 #else
 extern  CHAR                    _ux_version_id[];
 #endif

--- a/ports/cortex_m0/iar/inc/ux_port.h
+++ b/ports/cortex_m0/iar/inc/ux_port.h
@@ -247,8 +247,7 @@ VOID    outpl(ULONG,ULONG);
 
 #ifdef  UX_SYSTEM_INIT
 CHAR                            _ux_version_id[] =
-                                    "Copyright (c) 2024 Microsoft Corporation. * USBX Cortex-M0/IAR Version 6.4.1 *";
- * Copyright (c) 2026-present Eclipse ThreadX contributors
+                                    "(c) 2024 Microsoft Corp. (c) 2026-present Eclipse ThreadX contributors. * USBX Cortex-M0/IAR Version 6.5.0.202601 *";
 #else
 extern  CHAR                    _ux_version_id[];
 #endif

--- a/ports/cortex_m3/gnu/inc/ux_port.h
+++ b/ports/cortex_m3/gnu/inc/ux_port.h
@@ -243,8 +243,7 @@ VOID    outpl(ULONG,ULONG);
 
 #ifdef  UX_SYSTEM_INIT
 CHAR                            _ux_version_id[] =
-                                    "Copyright (c) 2024 Microsoft Corporation. * USBX Cortex-M3/GNU Version 6.4.1 *";
- * Copyright (c) 2026-present Eclipse ThreadX contributors
+                                    "(c) 2024 Microsoft Corp. (c) 2026-present Eclipse ThreadX contributors. * USBX Cortex-M3/GNU Version 6.5.0.202601 *";
 #else
 extern  CHAR                    _ux_version_id[];
 #endif

--- a/ports/cortex_m3/iar/inc/ux_port.h
+++ b/ports/cortex_m3/iar/inc/ux_port.h
@@ -245,8 +245,7 @@ VOID    outpl(ULONG,ULONG);
 
 #ifdef  UX_SYSTEM_INIT
 CHAR                            _ux_version_id[] =
-                                    "Copyright (c) 2024 Microsoft Corporation. * USBX Cortex-M3/IAR Version 6.4.1 *";
- * Copyright (c) 2026-present Eclipse ThreadX contributors
+                                    "(c) 2024 Microsoft Corp. (c) 2026-present Eclipse ThreadX contributors. * USBX Cortex-M3/IAR Version 6.5.0.202601 *";
 #else
 extern  CHAR                    _ux_version_id[];
 #endif

--- a/ports/cortex_m33/gnu/inc/ux_port.h
+++ b/ports/cortex_m33/gnu/inc/ux_port.h
@@ -243,8 +243,7 @@ VOID    outpl(ULONG,ULONG);
 
 #ifdef  UX_SYSTEM_INIT
 CHAR                            _ux_version_id[] =
-                                    "Copyright (c) 2024 Microsoft Corporation. * USBX Cortex-M33/GNU Version 6.4.1 *";
- * Copyright (c) 2026-present Eclipse ThreadX contributors
+                                    "(c) 2024 Microsoft Corp. (c) 2026-present Eclipse ThreadX contributors. * USBX Cortex-M33/GNU Version 6.5.0.202601 *";
 #else
 extern  CHAR                    _ux_version_id[];
 #endif

--- a/ports/cortex_m33/iar/inc/ux_port.h
+++ b/ports/cortex_m33/iar/inc/ux_port.h
@@ -247,8 +247,7 @@ VOID    outpl(ULONG,ULONG);
 
 #ifdef  UX_SYSTEM_INIT
 CHAR                            _ux_version_id[] =
-                                    "Copyright (c) 2024 Microsoft Corporation. * USBX Cortex-M33/IAR Version 6.4.1 *";
- * Copyright (c) 2026-present Eclipse ThreadX contributors
+                                    "(c) 2024 Microsoft Corp. (c) 2026-present Eclipse ThreadX contributors. * USBX Cortex-M33/IAR Version 6.5.0.202601 *";
 #else
 extern  CHAR                    _ux_version_id[];
 #endif

--- a/ports/cortex_m4/gnu/inc/ux_port.h
+++ b/ports/cortex_m4/gnu/inc/ux_port.h
@@ -243,8 +243,7 @@ VOID    outpl(ULONG,ULONG);
 
 #ifdef  UX_SYSTEM_INIT
 CHAR                            _ux_version_id[] =
-                                    "Copyright (c) 2024 Microsoft Corporation. * USBX Cortex-M4/GNU Version 6.4.1 *";
- * Copyright (c) 2026-present Eclipse ThreadX contributors
+                                    "(c) 2024 Microsoft Corp. (c) 2026-present Eclipse ThreadX contributors. * USBX Cortex-M4/GNU Version 6.5.0.202601 *";
 #else
 extern  CHAR                    _ux_version_id[];
 #endif

--- a/ports/cortex_m4/iar/inc/ux_port.h
+++ b/ports/cortex_m4/iar/inc/ux_port.h
@@ -247,8 +247,7 @@ VOID    outpl(ULONG,ULONG);
 
 #ifdef  UX_SYSTEM_INIT
 CHAR                            _ux_version_id[] =
-                                    "Copyright (c) 2024 Microsoft Corporation. * USBX Cortex-M4/IAR Version 6.4.1 *";
- * Copyright (c) 2026-present Eclipse ThreadX contributors
+                                    "(c) 2024 Microsoft Corp. (c) 2026-present Eclipse ThreadX contributors. * USBX Cortex-M4/IAR Version 6.5.0.202601 *";
 #else
 extern  CHAR                    _ux_version_id[];
 #endif

--- a/ports/cortex_m7/gnu/inc/ux_port.h
+++ b/ports/cortex_m7/gnu/inc/ux_port.h
@@ -243,8 +243,7 @@ VOID    outpl(ULONG,ULONG);
 
 #ifdef  UX_SYSTEM_INIT
 CHAR                            _ux_version_id[] =
-                                    "Copyright (c) 2024 Microsoft Corporation. * USBX Cortex-M7/GNU Version 6.4.1 *";
- * Copyright (c) 2026-present Eclipse ThreadX contributors
+                                    "(c) 2024 Microsoft Corp. (c) 2026-present Eclipse ThreadX contributors. * USBX Cortex-M7/GNU Version 6.5.0.202601 *";
 #else
 extern  CHAR                    _ux_version_id[];
 #endif

--- a/ports/cortex_m7/iar/inc/ux_port.h
+++ b/ports/cortex_m7/iar/inc/ux_port.h
@@ -247,8 +247,7 @@ VOID    outpl(ULONG,ULONG);
 
 #ifdef  UX_SYSTEM_INIT
 CHAR                            _ux_version_id[] =
-                                    "Copyright (c) 2024 Microsoft Corporation. * USBX Cortex-M7/IAR Version 6.4.1 *";
- * Copyright (c) 2026-present Eclipse ThreadX contributors
+                                    "(c) 2024 Microsoft Corp. (c) 2026-present Eclipse ThreadX contributors. * USBX Cortex-M7/IAR Version 6.5.0.202601 *";
 #else
 extern  CHAR                    _ux_version_id[];
 #endif

--- a/ports/cortex_r4/gnu/inc/ux_port.h
+++ b/ports/cortex_r4/gnu/inc/ux_port.h
@@ -244,8 +244,7 @@ VOID    outpl(ULONG,ULONG);
 
 #ifdef  UX_SYSTEM_INIT
 CHAR                            _ux_version_id[] =
-                                    "Copyright (c) 2024 Microsoft Corporation. * USBX Cortex-R4/GNU Version 6.4.1 *";
- * Copyright (c) 2026-present Eclipse ThreadX contributors
+                                    "(c) 2024 Microsoft Corp. (c) 2026-present Eclipse ThreadX contributors. * USBX Cortex-R4/GNU Version 6.5.0.202601 *";
 #else
 extern  CHAR                    _ux_version_id[];
 #endif

--- a/ports/cortex_r4/iar/inc/ux_port.h
+++ b/ports/cortex_r4/iar/inc/ux_port.h
@@ -247,8 +247,7 @@ VOID    outpl(ULONG,ULONG);
 
 #ifdef  UX_SYSTEM_INIT
 CHAR                            _ux_version_id[] =
-                                    "Copyright (c) 2024 Microsoft Corporation. * USBX Cortex-R4/IAR Version 6.4.1 *";
- * Copyright (c) 2026-present Eclipse ThreadX contributors
+                                    "(c) 2024 Microsoft Corp. (c) 2026-present Eclipse ThreadX contributors. * USBX Cortex-R4/IAR Version 6.5.0.202601 *";
 #else
 extern  CHAR                    _ux_version_id[];
 #endif

--- a/ports/cortex_r5/gnu/inc/ux_port.h
+++ b/ports/cortex_r5/gnu/inc/ux_port.h
@@ -246,8 +246,7 @@ VOID    outpl(ULONG,ULONG);
 
 #ifdef  UX_SYSTEM_INIT
 CHAR                            _ux_version_id[] =
-                                    "Copyright (c) 2024 Microsoft Corporation. * USBX Cortex-R5/GNU Version 6.4.1 *";
- * Copyright (c) 2026-present Eclipse ThreadX contributors
+                                    "(c) 2024 Microsoft Corp. (c) 2026-present Eclipse ThreadX contributors. * USBX Cortex-R5/GNU Version 6.5.0.202601 *";
 #else
 extern  CHAR                    _ux_version_id[];
 #endif

--- a/ports/cortex_r5/iar/inc/ux_port.h
+++ b/ports/cortex_r5/iar/inc/ux_port.h
@@ -248,8 +248,7 @@ VOID    outpl(ULONG,ULONG);
 
 #ifdef  UX_SYSTEM_INIT
 CHAR                            _ux_version_id[] =
-                                    "Copyright (c) 2024 Microsoft Corporation. * USBX Cortex-R5/IAR Version 6.4.1 *";
- * Copyright (c) 2026-present Eclipse ThreadX contributors
+                                    "(c) 2024 Microsoft Corp. (c) 2026-present Eclipse ThreadX contributors. * USBX Cortex-R5/IAR Version 6.5.0.202601 *";
 #else
 extern  CHAR                    _ux_version_id[];
 #endif

--- a/ports/generic/inc/ux_port.h
+++ b/ports/generic/inc/ux_port.h
@@ -247,8 +247,7 @@ VOID    outpl(ULONG,ULONG);
 
 #ifdef  UX_SYSTEM_INIT
 CHAR                            _ux_version_id[] =
-                                    "Copyright (c) 2024 Microsoft Corporation. * USBX Generic Version 6.4.1 *";
- * Copyright (c) 2026-present Eclipse ThreadX contributors
+                                    "(c) 2024 Microsoft Corp. (c) 2026-present Eclipse ThreadX contributors. * USBX Generic Version 6.5.0.202601 *";
 #else
 extern  CHAR                    _ux_version_id[];
 #endif

--- a/ports/linux/gnu/inc/ux_port.h
+++ b/ports/linux/gnu/inc/ux_port.h
@@ -249,8 +249,7 @@ ULONG   outpl(ULONG,ULONG);
 
 #ifdef  UX_SYSTEM_INIT
 CHAR                            _ux_version_id[] =
-                                    "Copyright (c) 2024 Microsoft Corporation. * USBX Linux/GNU Version 6.4.1 *";
- * Copyright (c) 2026-present Eclipse ThreadX contributors
+                                    "(c) 2024 Microsoft Corp. (c) 2026-present Eclipse ThreadX contributors. * USBX Linux/GNU Version 6.5.0.202601 *";
 #else
 extern  CHAR                    _ux_version_id[];
 #endif

--- a/ports/rxv1/gnu/inc/ux_port.h
+++ b/ports/rxv1/gnu/inc/ux_port.h
@@ -239,8 +239,7 @@ VOID    outpl(ULONG,ULONG);
 
 #ifdef  UX_SYSTEM_INIT
 CHAR                            _ux_version_id[] =
-                                    "Copyright (c) 2024 Microsoft Corporation. * USBX RXv1/GNU Version 6.4.1 *";
- * Copyright (c) 2026-present Eclipse ThreadX contributors
+                                    "(c) 2024 Microsoft Corp. (c) 2026-present Eclipse ThreadX contributors. * USBX RXv1/GNU Version 6.5.0.202601 *";
 #else
 extern  CHAR                    _ux_version_id[];
 #endif

--- a/ports/rxv2/gnu/inc/ux_port.h
+++ b/ports/rxv2/gnu/inc/ux_port.h
@@ -239,8 +239,7 @@ VOID    outpl(ULONG,ULONG);
 
 #ifdef  UX_SYSTEM_INIT
 CHAR                            _ux_version_id[] =
-                                    "Copyright (c) 2024 Microsoft Corporation. * USBX RXv2/GNU Version 6.4.1 *";
- * Copyright (c) 2026-present Eclipse ThreadX contributors
+                                    "(c) 2024 Microsoft Corp. (c) 2026-present Eclipse ThreadX contributors. * USBX RXv2/GNU Version 6.5.0.202601 *";
 #else
 extern  CHAR                    _ux_version_id[];
 #endif

--- a/ports/rxv3/gnu/inc/ux_port.h
+++ b/ports/rxv3/gnu/inc/ux_port.h
@@ -239,8 +239,7 @@ VOID    outpl(ULONG,ULONG);
 
 #ifdef  UX_SYSTEM_INIT
 CHAR                            _ux_version_id[] =
-                                    "Copyright (c) 2024 Microsoft Corporation. * USBX RXv3/GNU Version 6.4.1 *";
- * Copyright (c) 2026-present Eclipse ThreadX contributors
+                                    "(c) 2024 Microsoft Corp. (c) 2026-present Eclipse ThreadX contributors. * USBX RXv3/GNU Version 6.5.0.202601 *";
 #else
 extern  CHAR                    _ux_version_id[];
 #endif


### PR DESCRIPTION
* Removed misplaced copyright headers and updated port version strings

* Fixed issue where pointer size was used instead of buffer size in ux_host_class_hid_report_item_analyse