### PR TITLE
fix(hid): Store client instance per-device instead of per-class

### DIFF
--- a/common/usbx_host_classes/src/ux_host_class_hid_client_search.c
+++ b/common/usbx_host_classes/src/ux_host_class_hid_client_search.c
@@ -12,8 +12,8 @@
 
 /**************************************************************************/
 /**************************************************************************/
-/**                                                                       */ 
-/** USBX Component                                                        */ 
+/**                                                                       */
+/** USBX Component                                                        */
 /**                                                                       */
 /**   HID Class                                                           */
 /**                                                                       */
@@ -30,42 +30,46 @@
 #include "ux_host_stack.h"
 
 
-/**************************************************************************/ 
-/*                                                                        */ 
-/*  FUNCTION                                               RELEASE        */ 
-/*                                                                        */ 
-/*    _ux_host_class_hid_client_search                    PORTABLE C      */ 
+/**************************************************************************/
+/*                                                                        */
+/*  FUNCTION                                               RELEASE        */
+/*                                                                        */
+/*    _ux_host_class_hid_client_search                    PORTABLE C      */
 /*                                                           6.1          */
 /*  AUTHOR                                                                */
 /*                                                                        */
 /*    Chaoqiong Xiao, Microsoft Corporation                               */
 /*                                                                        */
 /*  DESCRIPTION                                                           */
-/*                                                                        */ 
+/*                                                                        */
 /*    This function searches for a HID client that wants to own this HID  */
-/*    device.                                                             */ 
-/*                                                                        */ 
-/*  INPUT                                                                 */ 
-/*                                                                        */ 
-/*    hid                                   Pointer to HID class          */ 
-/*                                                                        */ 
-/*  OUTPUT                                                                */ 
-/*                                                                        */ 
-/*    Completion Status                                                   */ 
-/*                                                                        */ 
-/*  CALLS                                                                 */ 
-/*                                                                        */ 
-/*    (ux_host_class_hid_client_handler)    HID client handler            */ 
-/*                                                                        */ 
-/*  CALLED BY                                                             */ 
-/*                                                                        */ 
-/*    HID Class                                                           */ 
+/*    device.                                                             */
+/*                                                                        */
+/*  INPUT                                                                 */
+/*                                                                        */
+/*    hid                                   Pointer to HID class          */
+/*                                                                        */
+/*  OUTPUT                                                                */
+/*                                                                        */
+/*    Completion Status                                                   */
+/*                                                                        */
+/*  CALLS                                                                 */
+/*                                                                        */
+/*    (ux_host_class_hid_client_handler)    HID client handler            */
+/*    _ux_utility_memory_allocate           Allocate memory block         */
+/*    _ux_utility_memory_copy               Copy memory block             */
+/*    _ux_utility_memory_free               Release memory block          */
+/*                                                                        */
+/*  CALLED BY                                                             */
+/*                                                                        */
+/*    HID Class                                                           */
 /*                                                                        */
 /**************************************************************************/
 UINT  _ux_host_class_hid_client_search(UX_HOST_CLASS_HID *hid)
 {
 
 UX_HOST_CLASS_HID_CLIENT            *hid_client;
+UX_HOST_CLASS_HID_CLIENT            *hid_client_instance;
 ULONG                               hid_client_index;
 UINT                                status;
 UX_HOST_CLASS_HID_CLIENT_COMMAND    hid_client_command;
@@ -77,10 +81,10 @@ UX_HOST_CLASS_HID_CLIENT_COMMAND    hid_client_command;
     hid_client_command.ux_host_class_hid_client_command_instance =   hid;
     hid_client_command.ux_host_class_hid_client_command_container =  (VOID *) hid -> ux_host_class_hid_class;
     hid_client_command.ux_host_class_hid_client_command_request =    UX_HOST_CLASS_COMMAND_QUERY;
-        
+
     /* Dereference the client pointer into a HID client pointer.  */
     hid_client =  (UX_HOST_CLASS_HID_CLIENT *) hid -> ux_host_class_hid_class -> ux_host_class_client;
-    
+
     /* If the hid_client pointer is NULL, the array of clients was not initialized.  */
     if (hid_client == UX_NULL)
     {
@@ -93,7 +97,7 @@ UX_HOST_CLASS_HID_CLIENT_COMMAND    hid_client_command;
 
         return(UX_HOST_CLASS_HID_UNKNOWN);
     }
-            
+
     /* We need to parse the hid client driver table to find a registered client.  */
     for (hid_client_index = 0; hid_client_index < UX_HOST_CLASS_HID_MAX_CLIENTS; hid_client_index++)
     {
@@ -104,24 +108,22 @@ UX_HOST_CLASS_HID_CLIENT_COMMAND    hid_client_command;
 
             /* Call the HID client with a query command.  */
             status =  hid_client -> ux_host_class_hid_client_handler(&hid_client_command);
-    
+
             /* Have we found a HID client?  */
             if (status == UX_SUCCESS)
             {
 
-                /* Allocate a per-instance copy of the client struct so that
-                   each HID device gets its own local_instance pointer.
-                   This prevents multiple devices of the same type from
-                   using a single local_instance.  */
-                UX_HOST_CLASS_HID_CLIENT *hid_client_instance;
+                /* Allocate a per-instance copy of the client struct so that each HID
+                   device gets its own local_instance pointer. This prevents multiple
+                   devices of the same type from sharing a single local_instance.  */
                 hid_client_instance = (UX_HOST_CLASS_HID_CLIENT *)
                     _ux_utility_memory_allocate(UX_NO_ALIGN, UX_REGULAR_MEMORY,
                                                 sizeof(UX_HOST_CLASS_HID_CLIENT));
                 if (hid_client_instance == UX_NULL)
                     return(UX_MEMORY_INSUFFICIENT);
 
-                /* Copy the registered client entry into the per-instance copy 
-                and NULL the local instance.  */
+                /* Copy the registered client entry and clear the local instance
+                   to avoid carrying a stale pointer from a prior activation.  */
                 _ux_utility_memory_copy(hid_client_instance, hid_client,
                                         sizeof(UX_HOST_CLASS_HID_CLIENT));
                 hid_client_instance -> ux_host_class_hid_client_local_instance = UX_NULL;
@@ -135,13 +137,13 @@ UX_HOST_CLASS_HID_CLIENT_COMMAND    hid_client_command;
                 /* Call the HID client with an activate command.  */
                 status =  hid_client_instance -> ux_host_class_hid_client_handler(&hid_client_command);
 
-                /* Unmount the client if activation fail. */
+                /* Unmount the client if activation failed. */
                 if (status != UX_SUCCESS)
                 {
                     hid -> ux_host_class_hid_client = UX_NULL;
                     _ux_utility_memory_free(hid_client_instance);
                 }
-        
+
                 /* Return completion status.  */
                 return(status);
             }
@@ -149,7 +151,7 @@ UX_HOST_CLASS_HID_CLIENT_COMMAND    hid_client_command;
 
         /* Try the next HID client.  */
         hid_client++;
-    }    
+    }
 
     /* Error trap. */
     _ux_system_error_handler(UX_SYSTEM_LEVEL_THREAD, UX_SYSTEM_CONTEXT_CLASS, UX_HOST_CLASS_HID_UNKNOWN);

--- a/common/usbx_host_classes/src/ux_host_class_hid_client_search.c
+++ b/common/usbx_host_classes/src/ux_host_class_hid_client_search.c
@@ -12,8 +12,8 @@
 
 /**************************************************************************/
 /**************************************************************************/
-/**                                                                       */
-/** USBX Component                                                        */
+/**                                                                       */ 
+/** USBX Component                                                        */ 
 /**                                                                       */
 /**   HID Class                                                           */
 /**                                                                       */
@@ -30,36 +30,36 @@
 #include "ux_host_stack.h"
 
 
-/**************************************************************************/
-/*                                                                        */
-/*  FUNCTION                                               RELEASE        */
-/*                                                                        */
-/*    _ux_host_class_hid_client_search                    PORTABLE C      */
+/**************************************************************************/ 
+/*                                                                        */ 
+/*  FUNCTION                                               RELEASE        */ 
+/*                                                                        */ 
+/*    _ux_host_class_hid_client_search                    PORTABLE C      */ 
 /*                                                           6.1          */
 /*  AUTHOR                                                                */
 /*                                                                        */
 /*    Chaoqiong Xiao, Microsoft Corporation                               */
 /*                                                                        */
 /*  DESCRIPTION                                                           */
-/*                                                                        */
+/*                                                                        */ 
 /*    This function searches for a HID client that wants to own this HID  */
-/*    device.                                                             */
-/*                                                                        */
-/*  INPUT                                                                 */
-/*                                                                        */
-/*    hid                                   Pointer to HID class          */
-/*                                                                        */
-/*  OUTPUT                                                                */
-/*                                                                        */
-/*    Completion Status                                                   */
-/*                                                                        */
-/*  CALLS                                                                 */
-/*                                                                        */
-/*    (ux_host_class_hid_client_handler)    HID client handler            */
-/*                                                                        */
-/*  CALLED BY                                                             */
-/*                                                                        */
-/*    HID Class                                                           */
+/*    device.                                                             */ 
+/*                                                                        */ 
+/*  INPUT                                                                 */ 
+/*                                                                        */ 
+/*    hid                                   Pointer to HID class          */ 
+/*                                                                        */ 
+/*  OUTPUT                                                                */ 
+/*                                                                        */ 
+/*    Completion Status                                                   */ 
+/*                                                                        */ 
+/*  CALLS                                                                 */ 
+/*                                                                        */ 
+/*    (ux_host_class_hid_client_handler)    HID client handler            */ 
+/*                                                                        */ 
+/*  CALLED BY                                                             */ 
+/*                                                                        */ 
+/*    HID Class                                                           */ 
 /*                                                                        */
 /**************************************************************************/
 UINT  _ux_host_class_hid_client_search(UX_HOST_CLASS_HID *hid)
@@ -77,10 +77,10 @@ UX_HOST_CLASS_HID_CLIENT_COMMAND    hid_client_command;
     hid_client_command.ux_host_class_hid_client_command_instance =   hid;
     hid_client_command.ux_host_class_hid_client_command_container =  (VOID *) hid -> ux_host_class_hid_class;
     hid_client_command.ux_host_class_hid_client_command_request =    UX_HOST_CLASS_COMMAND_QUERY;
-
+        
     /* Dereference the client pointer into a HID client pointer.  */
     hid_client =  (UX_HOST_CLASS_HID_CLIENT *) hid -> ux_host_class_hid_class -> ux_host_class_client;
-
+    
     /* If the hid_client pointer is NULL, the array of clients was not initialized.  */
     if (hid_client == UX_NULL)
     {
@@ -93,7 +93,7 @@ UX_HOST_CLASS_HID_CLIENT_COMMAND    hid_client_command;
 
         return(UX_HOST_CLASS_HID_UNKNOWN);
     }
-
+            
     /* We need to parse the hid client driver table to find a registered client.  */
     for (hid_client_index = 0; hid_client_index < UX_HOST_CLASS_HID_MAX_CLIENTS; hid_client_index++)
     {
@@ -104,24 +104,44 @@ UX_HOST_CLASS_HID_CLIENT_COMMAND    hid_client_command;
 
             /* Call the HID client with a query command.  */
             status =  hid_client -> ux_host_class_hid_client_handler(&hid_client_command);
-
+    
             /* Have we found a HID client?  */
             if (status == UX_SUCCESS)
             {
 
+                /* Allocate a per-instance copy of the client struct so that
+                   each HID device gets its own local_instance pointer.
+                   This prevents multiple devices of the same type from
+                   using a single local_instance.  */
+                UX_HOST_CLASS_HID_CLIENT *hid_client_instance;
+                hid_client_instance = (UX_HOST_CLASS_HID_CLIENT *)
+                    _ux_utility_memory_allocate(UX_NO_ALIGN, UX_REGULAR_MEMORY,
+                                                sizeof(UX_HOST_CLASS_HID_CLIENT));
+                if (hid_client_instance == UX_NULL)
+                    return(UX_MEMORY_INSUFFICIENT);
+
+                /* Copy the registered client entry into the per-instance copy 
+                and NULL the local instance.  */
+                _ux_utility_memory_copy(hid_client_instance, hid_client,
+                                        sizeof(UX_HOST_CLASS_HID_CLIENT));
+                hid_client_instance -> ux_host_class_hid_client_local_instance = UX_NULL;
+
                 /* Update the command to activate the client.  */
                 hid_client_command.ux_host_class_hid_client_command_request =  UX_HOST_CLASS_COMMAND_ACTIVATE;
 
-                /* Memorize the client for this HID device.  */
-                hid -> ux_host_class_hid_client =  hid_client;
+                /* Store the per-instance client on this HID device.  */
+                hid -> ux_host_class_hid_client =  hid_client_instance;
 
                 /* Call the HID client with an activate command.  */
-                status =  hid_client -> ux_host_class_hid_client_handler(&hid_client_command);
+                status =  hid_client_instance -> ux_host_class_hid_client_handler(&hid_client_command);
 
                 /* Unmount the client if activation fail. */
                 if (status != UX_SUCCESS)
+                {
                     hid -> ux_host_class_hid_client = UX_NULL;
-
+                    _ux_utility_memory_free(hid_client_instance);
+                }
+        
                 /* Return completion status.  */
                 return(status);
             }
@@ -129,7 +149,7 @@ UX_HOST_CLASS_HID_CLIENT_COMMAND    hid_client_command;
 
         /* Try the next HID client.  */
         hid_client++;
-    }
+    }    
 
     /* Error trap. */
     _ux_system_error_handler(UX_SYSTEM_LEVEL_THREAD, UX_SYSTEM_CONTEXT_CLASS, UX_HOST_CLASS_HID_UNKNOWN);

--- a/common/usbx_host_classes/src/ux_host_class_hid_deactivate.c
+++ b/common/usbx_host_classes/src/ux_host_class_hid_deactivate.c
@@ -12,8 +12,8 @@
 
 /**************************************************************************/
 /**************************************************************************/
-/**                                                                       */
-/** USBX Component                                                        */
+/**                                                                       */ 
+/** USBX Component                                                        */ 
 /**                                                                       */
 /**   HID Class                                                           */
 /**                                                                       */
@@ -30,44 +30,44 @@
 #include "ux_host_stack.h"
 
 
-/**************************************************************************/
-/*                                                                        */
-/*  FUNCTION                                               RELEASE        */
-/*                                                                        */
-/*    _ux_host_class_hid_deactivate                       PORTABLE C      */
+/**************************************************************************/ 
+/*                                                                        */ 
+/*  FUNCTION                                               RELEASE        */ 
+/*                                                                        */ 
+/*    _ux_host_class_hid_deactivate                       PORTABLE C      */ 
 /*                                                           6.1.10       */
 /*  AUTHOR                                                                */
 /*                                                                        */
 /*    Chaoqiong Xiao, Microsoft Corporation                               */
 /*                                                                        */
 /*  DESCRIPTION                                                           */
-/*                                                                        */
+/*                                                                        */ 
 /*    This function is called when this instance of the HID has been      */
-/*    removed from the bus either directly or indirectly. The interrupt   */
-/*    pipe will be destroyed and the instanced removed.                   */
-/*                                                                        */
-/*  INPUT                                                                 */
-/*                                                                        */
-/*    command                               Pointer to command            */
-/*                                                                        */
-/*  OUTPUT                                                                */
-/*                                                                        */
-/*    Completion Status                                                   */
-/*                                                                        */
-/*  CALLS                                                                 */
-/*                                                                        */
-/*    (ux_host_class_hid_client_handler)    HID client handler            */
-/*    _ux_host_class_hid_instance_clean     HID instance clean            */
-/*    _ux_host_stack_class_instance_destroy Destroy the class instance    */
+/*    removed from the bus either directly or indirectly. The interrupt   */ 
+/*    pipe will be destroyed and the instanced removed.                   */ 
+/*                                                                        */ 
+/*  INPUT                                                                 */ 
+/*                                                                        */ 
+/*    command                               Pointer to command            */ 
+/*                                                                        */ 
+/*  OUTPUT                                                                */ 
+/*                                                                        */ 
+/*    Completion Status                                                   */ 
+/*                                                                        */ 
+/*  CALLS                                                                 */ 
+/*                                                                        */ 
+/*    (ux_host_class_hid_client_handler)    HID client handler            */ 
+/*    _ux_host_class_hid_instance_clean     HID instance clean            */ 
+/*    _ux_host_stack_class_instance_destroy Destroy the class instance    */ 
 /*    _ux_host_stack_endpoint_transfer_abort                              */
-/*                                          Abort transfer                */
-/*    _ux_utility_memory_free               Release memory block          */
-/*    _ux_host_semaphore_delete             Delete semaphore              */
-/*    _ux_host_semaphore_get                Get semaphore                 */
-/*                                                                        */
-/*  CALLED BY                                                             */
-/*                                                                        */
-/*    HID Class                                                           */
+/*                                          Abort transfer                */ 
+/*    _ux_utility_memory_free               Release memory block          */ 
+/*    _ux_host_semaphore_delete             Delete semaphore              */ 
+/*    _ux_host_semaphore_get                Get semaphore                 */ 
+/*                                                                        */ 
+/*  CALLED BY                                                             */ 
+/*                                                                        */ 
+/*    HID Class                                                           */ 
 /*                                                                        */
 /**************************************************************************/
 UINT  _ux_host_class_hid_deactivate(UX_HOST_CLASS_COMMAND *command)
@@ -138,17 +138,23 @@ UINT                                status;
     hid_client_command.ux_host_class_hid_client_command_instance =   (VOID *) hid;
     hid_client_command.ux_host_class_hid_client_command_container =  (VOID *) hid -> ux_host_class_hid_class;
     hid_client_command.ux_host_class_hid_client_command_request =    UX_HOST_CLASS_COMMAND_DEACTIVATE;
-
+    
     /* Call the HID client with a deactivate command if there was a client registered.  */
     if (hid -> ux_host_class_hid_client != UX_NULL)
+    {
         hid -> ux_host_class_hid_client -> ux_host_class_hid_client_handler(&hid_client_command);
+
+        /* Free the per-instance client copy allocated in _ux_host_class_hid_client_search.  */
+        _ux_utility_memory_free(hid -> ux_host_class_hid_client);
+        hid -> ux_host_class_hid_client = UX_NULL;
+    }
 
     /* Clean all the HID memory fields.  */
     _ux_host_class_hid_instance_clean(hid);
 
     /* The enumeration thread needs to sleep a while to allow the application or the class that may be using
        endpoints to exit properly.  */
-    _ux_host_thread_schedule_other(UX_THREAD_PRIORITY_ENUM);
+    _ux_host_thread_schedule_other(UX_THREAD_PRIORITY_ENUM); 
 
     /* Destroy the instance.  */
     _ux_host_stack_class_instance_destroy(hid -> ux_host_class_hid_class, (VOID *) hid);
@@ -160,7 +166,7 @@ UINT                                status;
         that the device is removed.  */
     if (_ux_system_host -> ux_system_host_change_function != UX_NULL)
     {
-
+        
         /* Inform the application the device is removed.  */
         _ux_system_host -> ux_system_host_change_function(UX_DEVICE_REMOVAL, hid -> ux_host_class_hid_class, (VOID *) hid);
     }
@@ -175,5 +181,6 @@ UINT                                status;
     _ux_utility_memory_free(hid);
 
     /* Return successful completion.  */
-    return(UX_SUCCESS);
+    return(UX_SUCCESS);         
 }
+

--- a/common/usbx_host_classes/src/ux_host_class_hid_deactivate.c
+++ b/common/usbx_host_classes/src/ux_host_class_hid_deactivate.c
@@ -12,8 +12,8 @@
 
 /**************************************************************************/
 /**************************************************************************/
-/**                                                                       */ 
-/** USBX Component                                                        */ 
+/**                                                                       */
+/** USBX Component                                                        */
 /**                                                                       */
 /**   HID Class                                                           */
 /**                                                                       */
@@ -30,44 +30,44 @@
 #include "ux_host_stack.h"
 
 
-/**************************************************************************/ 
-/*                                                                        */ 
-/*  FUNCTION                                               RELEASE        */ 
-/*                                                                        */ 
-/*    _ux_host_class_hid_deactivate                       PORTABLE C      */ 
+/**************************************************************************/
+/*                                                                        */
+/*  FUNCTION                                               RELEASE        */
+/*                                                                        */
+/*    _ux_host_class_hid_deactivate                       PORTABLE C      */
 /*                                                           6.1.10       */
 /*  AUTHOR                                                                */
 /*                                                                        */
 /*    Chaoqiong Xiao, Microsoft Corporation                               */
 /*                                                                        */
 /*  DESCRIPTION                                                           */
-/*                                                                        */ 
+/*                                                                        */
 /*    This function is called when this instance of the HID has been      */
-/*    removed from the bus either directly or indirectly. The interrupt   */ 
-/*    pipe will be destroyed and the instanced removed.                   */ 
-/*                                                                        */ 
-/*  INPUT                                                                 */ 
-/*                                                                        */ 
-/*    command                               Pointer to command            */ 
-/*                                                                        */ 
-/*  OUTPUT                                                                */ 
-/*                                                                        */ 
-/*    Completion Status                                                   */ 
-/*                                                                        */ 
-/*  CALLS                                                                 */ 
-/*                                                                        */ 
-/*    (ux_host_class_hid_client_handler)    HID client handler            */ 
-/*    _ux_host_class_hid_instance_clean     HID instance clean            */ 
-/*    _ux_host_stack_class_instance_destroy Destroy the class instance    */ 
+/*    removed from the bus either directly or indirectly. The interrupt   */
+/*    pipe will be destroyed and the instanced removed.                   */
+/*                                                                        */
+/*  INPUT                                                                 */
+/*                                                                        */
+/*    command                               Pointer to command            */
+/*                                                                        */
+/*  OUTPUT                                                                */
+/*                                                                        */
+/*    Completion Status                                                   */
+/*                                                                        */
+/*  CALLS                                                                 */
+/*                                                                        */
+/*    (ux_host_class_hid_client_handler)    HID client handler            */
+/*    _ux_host_class_hid_instance_clean     HID instance clean            */
+/*    _ux_host_stack_class_instance_destroy Destroy the class instance    */
 /*    _ux_host_stack_endpoint_transfer_abort                              */
-/*                                          Abort transfer                */ 
-/*    _ux_utility_memory_free               Release memory block          */ 
-/*    _ux_host_semaphore_delete             Delete semaphore              */ 
-/*    _ux_host_semaphore_get                Get semaphore                 */ 
-/*                                                                        */ 
-/*  CALLED BY                                                             */ 
-/*                                                                        */ 
-/*    HID Class                                                           */ 
+/*                                          Abort transfer                */
+/*    _ux_utility_memory_free               Release memory block          */
+/*    _ux_host_semaphore_delete             Delete semaphore              */
+/*    _ux_host_semaphore_get                Get semaphore                 */
+/*                                                                        */
+/*  CALLED BY                                                             */
+/*                                                                        */
+/*    HID Class                                                           */
 /*                                                                        */
 /**************************************************************************/
 UINT  _ux_host_class_hid_deactivate(UX_HOST_CLASS_COMMAND *command)
@@ -154,7 +154,7 @@ UINT                                status;
 
     /* The enumeration thread needs to sleep a while to allow the application or the class that may be using
        endpoints to exit properly.  */
-    _ux_host_thread_schedule_other(UX_THREAD_PRIORITY_ENUM); 
+    _ux_host_thread_schedule_other(UX_THREAD_PRIORITY_ENUM);
 
     /* Destroy the instance.  */
     _ux_host_stack_class_instance_destroy(hid -> ux_host_class_hid_class, (VOID *) hid);
@@ -166,7 +166,7 @@ UINT                                status;
         that the device is removed.  */
     if (_ux_system_host -> ux_system_host_change_function != UX_NULL)
     {
-        
+
         /* Inform the application the device is removed.  */
         _ux_system_host -> ux_system_host_change_function(UX_DEVICE_REMOVAL, hid -> ux_host_class_hid_class, (VOID *) hid);
     }
@@ -181,6 +181,5 @@ UINT                                status;
     _ux_utility_memory_free(hid);
 
     /* Return successful completion.  */
-    return(UX_SUCCESS);         
+    return(UX_SUCCESS);
 }
-

--- a/common/usbx_host_classes/src/ux_host_class_hid_entry.c
+++ b/common/usbx_host_classes/src/ux_host_class_hid_entry.c
@@ -456,6 +456,7 @@ UINT                                status;
     /* Error.  */
     if (status < UX_STATE_NEXT)
     {
+        _ux_utility_memory_free(hid -> ux_host_class_hid_client);
         hid -> ux_host_class_hid_client = UX_NULL;
         hid -> ux_host_class_hid_status = UX_DEVICE_ENUMERATION_FAILURE;
         hid -> ux_host_class_hid_enum_state = UX_HOST_CLASS_HID_ENUM_ERROR;


### PR DESCRIPTION
# USBX HID Shared Client Instance Pointer Bug

## Target Repo

`eclipse-threadx/usbx` (MIT license, Category A Simple Contribution)

---

## Symptom

This bug surfaces when a user plugs in two or more HID devices of the same class to the hub tree. Removing any one HID device of a given type (keyboard or mouse) causes all remaining devices of that type to stop reporting input. Callbacks write into freed memory.

---

## Background: The Global Client Table

At startup, the application registers HID client types (keyboard, mouse) by calling `ux_host_class_hid_client_register()`. This function allocates a single flat array of `UX_HOST_CLASS_HID_CLIENT` structs, stored at `class->ux_host_class_client` on the `UX_HOST_CLASS` container for HID. In this application there are two entries:

```
class->ux_host_class_client -> [ [0]: keyboard handler | local_instance ]
                               [ [1]: mouse handler    | local_instance ]
```

Each entry holds a handler function pointer (e.g. `ux_host_class_hid_keyboard_entry`) and a `VOID *ux_host_class_hid_client_local_instance` field intended to point to the per-device instance (e.g. `UX_HOST_CLASS_HID_KEYBOARD`).

---

## Original Code: Device Activation Sequence

When a USB HID device enumerates, the middleware creates a per-interface `UX_HOST_CLASS_HID` struct (`hid`) and calls `_ux_host_class_hid_client_search(hid)`. This function:

1. Iterates the global client table to find a matching client (by HID usage page/usage).
2. Stores a direct pointer to the matching table entry on the HID instance:
   ```c
   hid->ux_host_class_hid_client = hid_client;  // points into the shared table
   ```
3. Calls the client's activate handler (e.g. `_ux_host_class_hid_keyboard_activate`).

The activate handler then:

1. Reads the client pointer back: `hid_client = hid->ux_host_class_hid_client`
2. Allocates a new `UX_HOST_CLASS_HID_KEYBOARD` struct (`keyboard_instance`)
3. Stores it on the shared table entry:
   ```c
   hid_client->ux_host_class_hid_client_local_instance = (VOID *)keyboard_instance;
   ```

The problem: `hid_client` points to the shared table entry. Every keyboard shares the same entry. The `local_instance` field is a single pointer — the last keyboard to activate overwrites it.

---

## Original Code: Device Deactivation Sequence

When a device is unplugged, `_ux_host_class_hid_keyboard_deactivate()` runs:

1. Reads the client pointer: `hid_client = hid->ux_host_class_hid_client` (shared entry)
2. Reads the keyboard instance: `keyboard_instance = hid_client->local_instance`
3. Frees the keyboard instance's thread, semaphore, buffers, and the instance itself.

The deactivation has no other way to find the keyboard instance. The address was only
ever stored in one place: `hid_client->local_instance` on the shared table entry.

---

## Failure Sequence (Two Keyboards, A and B)

```
1. Keyboard A activates
   -> shared_entry.local_instance = keyboard_instance_A

2. Keyboard B activates
   -> shared_entry.local_instance = keyboard_instance_B  (overwrites A)

   State: hid_A->hid_client -> shared_entry -> keyboard_instance_B
          hid_B->hid_client -> shared_entry -> keyboard_instance_B
          keyboard_instance_A exists in memory but nothing points to it

3. Keyboard A is unplugged
   -> deactivate reads shared_entry.local_instance -> gets keyboard_instance_B
   -> frees keyboard_instance_B (WRONG — this belongs to the still-connected keyboard)

   State: hid_B is still active, interrupt endpoint still delivering data
          hid_B's callback reads shared_entry.local_instance -> dangling pointer
          keyboard_instance_A is leaked (never freed, nothing references it)
```

Keyboard B's interrupt reports continue to arrive, but the callback writes into freed memory. The result is silent data loss and memory leak.

---

## Fix

Instead of storing a pointer to the shared table entry, allocate a per-instance copy of the client struct so each HID device gets its own `local_instance` pointer.

In `_ux_host_class_hid_client_search()` (lines 119–155):

```c
UX_HOST_CLASS_HID_CLIENT *hid_client_instance;
hid_client_instance = _ux_utility_memory_allocate(..., sizeof(UX_HOST_CLASS_HID_CLIENT));
_ux_utility_memory_copy(hid_client_instance, hid_client, sizeof(UX_HOST_CLASS_HID_CLIENT));
hid_client_instance->ux_host_class_hid_client_local_instance = UX_NULL;
hid->ux_host_class_hid_client = hid_client_instance;
```

The copy inherits the handler function pointer and name from the shared entry but has its own `local_instance` field. `local_instance` is explicitly set to NULL so the copy doesn't carry a stale pointer from a previous activation of the same device type. The activate handler then writes the freshly allocated keyboard instance to this private
copy's `local_instance`.

In `_ux_host_class_hid_deactivate()`, the per-instance copy is freed after the client deactivate handler runs:

```c
_ux_utility_memory_free(hid->ux_host_class_hid_client);
hid->ux_host_class_hid_client = UX_NULL;
```

---

## Fixed Sequence (Two Keyboards, A and B)

```
1. Keyboard A activates
   -> private_copy_A.local_instance = keyboard_instance_A
   -> hid_A->hid_client = private_copy_A

2. Keyboard B activates
   -> private_copy_B.local_instance = keyboard_instance_B
   -> hid_B->hid_client = private_copy_B

3. Keyboard A is unplugged
   -> deactivate reads private_copy_A.local_instance -> keyboard_instance_A (CORRECT)
   -> frees keyboard_instance_A, then frees private_copy_A

   Keyboard B is completely untouched.
```

---

## Files Changed

- `common/usbx_host_classes/src/ux_host_class_hid_client_search.c` (lines 119–155)
- `common/usbx_host_classes/src/ux_host_class_hid_deactivate.c`

---

## Memory Cost

One additional `sizeof(UX_HOST_CLASS_HID_CLIENT)` allocation (~40 bytes) per connected
HID device. Freed on device removal.
