### PR TITLE
Flagged four USBX functions as deprecated

### DIFF
--- a/common/core/src/ux_device_stack_interface_get.c
+++ b/common/core/src/ux_device_stack_interface_get.c
@@ -29,6 +29,19 @@
 #include "ux_device_stack.h"
 
 
+/* DEPRECATION NOTICE
+ * _ux_device_stack_interface_get() is deprecated. Do not use it in new code.
+ *
+ * WHY: this function was renamed to _ux_device_stack_alternate_setting_get()
+ * to better reflect its semantics (it retrieves the current alternate setting
+ * for an interface, not the interface itself). The core stack uses the new
+ * name exclusively.
+ *
+ * WHAT TO DO: replace calls with ux_device_stack_alternate_setting_get().
+ */
+#pragma message("_ux_device_stack_interface_get() is deprecated. " \
+                "Use ux_device_stack_alternate_setting_get() instead.")
+
 /**************************************************************************/
 /*                                                                        */
 /*  FUNCTION                                               RELEASE        */
@@ -41,10 +54,8 @@
 /*                                                                        */
 /*  DESCRIPTION                                                           */
 /*                                                                        */
-/*    This function is deprecated, ux_device_stack_alternate_setting_get  */
-/*    does the same thing and used by the core stack.                     */
-/*                                                                        */
-/*    This function gets the current alternate setting for an interface.  */
+/*    DEPRECATED. Use _ux_device_stack_alternate_setting_get() instead.   */
+/*    This function was renamed; the two are functionally identical.      */
 /*                                                                        */
 /*  INPUT                                                                 */
 /*                                                                        */

--- a/common/core/src/ux_utility_memory_free_block_best_get.c
+++ b/common/core/src/ux_utility_memory_free_block_best_get.c
@@ -40,9 +40,10 @@
 /*                                                                        */
 /*  DESCRIPTION                                                           */
 /*                                                                        */
-/*    This function returns the best free memory block.                   */
-/*                                                                        */
-/*    It's deprecated.                                                    */
+/*    DEPRECATED. This function is already disabled (compiled out via     */
+/*    #if 0) and exists only as a reference. The allocator implementation */
+/*    it served has been superseded by the current USBX memory            */
+/*    management layer. Do not re-enable or reference this function.      */
 /*                                                                        */
 /*  INPUT                                                                 */
 /*                                                                        */

--- a/common/core/src/ux_utility_string_length_get.c
+++ b/common/core/src/ux_utility_string_length_get.c
@@ -28,6 +28,19 @@
 #include "ux_api.h"
 
 
+/* DEPRECATION NOTICE
+ * _ux_utility_string_length_get() is deprecated. Do not use it in new code.
+ *
+ * WHY: this function scans the string until it finds a NUL byte with no
+ * upper bound on the search. If the buffer is not properly NUL-terminated,
+ * the scan reads past the end of the buffer, which is undefined behaviour.
+ *
+ * WHAT TO DO: replace calls with _ux_utility_string_length_check(), passing
+ * the maximum buffer length as an additional argument.
+ */
+#pragma message("_ux_utility_string_length_get() is deprecated. " \
+                "Use _ux_utility_string_length_check() and pass the buffer length.")
+
 /**************************************************************************/
 /*                                                                        */
 /*  FUNCTION                                               RELEASE        */
@@ -40,13 +53,9 @@
 /*                                                                        */
 /*  DESCRIPTION                                                           */
 /*                                                                        */
-/*    This function derives the length of a NULL-terminated string.       */
-/*                                                                        */
-/*    This function is deprecated, for the possible issue of operating on */
-/*    a buffer that is not NULL-terminated. As a replacement,             */
-/*    _ux_utility_string_length_check should be used, where the length of */
-/*    the buffer is introduced to validate the string by checking for the */
-/*    NULL-terminator within the buffer length.                           */
+/*    DEPRECATED. Use _ux_utility_string_length_check() instead, passing  */
+/*    the maximum buffer length. This function scans without an upper     */
+/*    bound; a non-NUL-terminated buffer causes an overread.              */
 /*                                                                        */
 /*  INPUT                                                                 */
 /*                                                                        */

--- a/common/usbx_host_classes/src/ux_host_class_asix_reception_callback.c
+++ b/common/usbx_host_classes/src/ux_host_class_asix_reception_callback.c
@@ -42,11 +42,9 @@
 /*                                                                        */
 /*  DESCRIPTION                                                           */
 /*                                                                        */
-/*    This function is the callback from the USBX transfer functions,     */
-/*    it is called when a full or partial transfer has been done for a    */
-/*    bulk in transfer. It calls back the application.                    */
-/*                                                                        */
-/*    It's deprecated.                                                    */
+/*    DEPRECATED. The ASIX host class reception path has been redesigned; */
+/*    this callback is no longer registered or invoked by the driver.     */
+/*    Do not call this function directly.                                 */
 /*                                                                        */
 /*  INPUT                                                                 */
 /*                                                                        */


### PR DESCRIPTION
## Summary

| Function | Status | Replacement |
|---|---|---|
| `ux_device_stack_interface_get` | Renamed | `ux_device_stack_alternate_setting_get` |
| `ux_utility_string_length_get` | Unsafe (no bound) | `ux_utility_string_length_check` |
| `ux_utility_memory_free_block_best_get` | Already dead code (`#if 0`) | none |
| `ux_host_class_asix_reception_callback` | No longer invoked by driver | none |

## Changes
- `ux_device_stack_interface_get.c`: added `#pragma message` + updated DESCRIPTION.
- `ux_utility_string_length_get.c`: added `#pragma message` + updated DESCRIPTION (no-bound overread risk).
- `ux_utility_memory_free_block_best_get.c`: updated DESCRIPTION to clarify it is dead code.
- `ux_host_class_asix_reception_callback.c`: updated DESCRIPTION.

## Companion
Docs: eclipse-threadx/rtos-docs-asciidoc#33 (pending)